### PR TITLE
Bump sqlparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +99,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -151,12 +172,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -236,13 +286,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlparser"
-version = "0.52.0"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sqlparser"
+version = "0.53.0"
+source = "git+https://github.com/cipherstash/datafusion-sqlparser-rs.git#10664409c4b82853647f50f4178d0c914b73fc41"
 dependencies = [
  "bigdecimal",
  "log",
+ "recursive",
 ]
 
 [[package]]
@@ -265,6 +321,19 @@ dependencies = [
  "quote",
  "sqlparser",
  "syn",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799c883d55abdb5e98af1a7b3f23b9b6de8ecada0ecac058672d7635eb48ca7b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys",
 ]
 
 [[package]]
@@ -303,3 +372,76 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ repository = "https://github.com/cipherstash/sqltk"
 homepage = "https://cipherstash.com"
 keywords = ["sqlparser", "database", "sql"]
 categories = ["sql", "database"]
+
+[workspace.dependencies]
+bigdecimal = { version = "^0.4" }
+sqlparser = { git = "https://github.com/cipherstash/datafusion-sqlparser-rs.git", commit = "10664409c4b82853647f50f4178d0c914b73fc41", features = ["bigdecimal"] }

--- a/packages/sqltk-codegen/Cargo.toml
+++ b/packages/sqltk-codegen/Cargo.toml
@@ -26,5 +26,5 @@ quote = { version = "^1" }
 prettyplease = "^0.2"
 cargo_metadata = "^0.19"
 Inflector = "^0.11"
-bigdecimal = { version = "^0.4" }
-sqlparser = { version = "^0.52", features = ["bigdecimal"] }
+bigdecimal = { workspace = true }
+sqlparser = { workspace = true }

--- a/packages/sqltk/Cargo.toml
+++ b/packages/sqltk/Cargo.toml
@@ -30,6 +30,6 @@ include = [
 ]
 
 [dependencies]
-bigdecimal = { version = "^0.4" }
-sqlparser = { version = "^0.52", features = ["bigdecimal"]}
+bigdecimal = { workspace = true }
+sqlparser = { workspace = true }
 

--- a/packages/sqltk/src/generated/transformable_impls.rs
+++ b/packages/sqltk/src/generated/transformable_impls.rs
@@ -1,4 +1,24 @@
 #[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::AccessExpr {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::AccessExpr::Dot(field0) => {
+                let transformed =
+                    sqlparser::ast::AccessExpr::Dot(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::AccessExpr::Subscript(field0) => {
+                let transformed =
+                    sqlparser::ast::AccessExpr::Subscript(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Action {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -536,6 +556,21 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::AlterTableOperation {
                 };
                 transformer.transform(self, transformed)
             }
+            sqlparser::ast::AlterTableOperation::ClusterBy { exprs } => {
+                let transformed = sqlparser::ast::AlterTableOperation::ClusterBy {
+                    exprs: exprs.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::AlterTableOperation::DropClusteringKey => {
+                transformer.transform(self, sqlparser::ast::AlterTableOperation::DropClusteringKey)
+            }
+            sqlparser::ast::AlterTableOperation::SuspendRecluster => {
+                transformer.transform(self, sqlparser::ast::AlterTableOperation::SuspendRecluster)
+            }
+            sqlparser::ast::AlterTableOperation::ResumeRecluster => {
+                transformer.transform(self, sqlparser::ast::AlterTableOperation::ResumeRecluster)
+            }
         }
     }
 }
@@ -674,6 +709,22 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::AttachDuckDBDatabaseOp
                     field0.apply_transform(transformer)?,
                 );
                 transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::BeginTransactionKind {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::BeginTransactionKind::Transaction => {
+                transformer.transform(self, sqlparser::ast::BeginTransactionKind::Transaction)
+            }
+            sqlparser::ast::BeginTransactionKind::Work => {
+                transformer.transform(self, sqlparser::ast::BeginTransactionKind::Work)
             }
         }
     }
@@ -1242,6 +1293,18 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::CommentObject {
             sqlparser::ast::CommentObject::Extension => {
                 transformer.transform(self, sqlparser::ast::CommentObject::Extension)
             }
+            sqlparser::ast::CommentObject::Schema => {
+                transformer.transform(self, sqlparser::ast::CommentObject::Schema)
+            }
+            sqlparser::ast::CommentObject::Database => {
+                transformer.transform(self, sqlparser::ast::CommentObject::Database)
+            }
+            sqlparser::ast::CommentObject::User => {
+                transformer.transform(self, sqlparser::ast::CommentObject::User)
+            }
+            sqlparser::ast::CommentObject::Role => {
+                transformer.transform(self, sqlparser::ast::CommentObject::Role)
+            }
         }
     }
 }
@@ -1503,6 +1566,49 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::CopyTarget {
                 transformer.transform(self, transformed)
             }
         }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::CreateFunction {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            or_replace,
+            temporary,
+            if_not_exists,
+            name,
+            args,
+            return_type,
+            function_body,
+            behavior,
+            called_on_null,
+            parallel,
+            using,
+            language,
+            determinism_specifier,
+            options,
+            remote_connection,
+        } = self;
+        let transformed = Self {
+            or_replace: or_replace.apply_transform(transformer)?,
+            temporary: temporary.apply_transform(transformer)?,
+            if_not_exists: if_not_exists.apply_transform(transformer)?,
+            name: name.apply_transform(transformer)?,
+            args: args.apply_transform(transformer)?,
+            return_type: return_type.apply_transform(transformer)?,
+            function_body: function_body.apply_transform(transformer)?,
+            behavior: behavior.apply_transform(transformer)?,
+            called_on_null: called_on_null.apply_transform(transformer)?,
+            parallel: parallel.apply_transform(transformer)?,
+            using: using.apply_transform(transformer)?,
+            language: language.apply_transform(transformer)?,
+            determinism_specifier: determinism_specifier.apply_transform(transformer)?,
+            options: options.apply_transform(transformer)?,
+            remote_connection: remote_connection.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
     }
 }
 #[automatically_derived]
@@ -1771,12 +1877,14 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Cte {
             query,
             from,
             materialized,
+            closing_paren_token,
         } = self;
         let transformed = Self {
             alias: alias.apply_transform(transformer)?,
             query: query.apply_transform(transformer)?,
             from: from.apply_transform(transformer)?,
             materialized: materialized.apply_transform(transformer)?,
+            closing_paren_token: closing_paren_token.apply_transform(transformer)?,
         };
         transformer.transform(self, transformed)
     }
@@ -1868,6 +1976,15 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::DataType {
                 let transformed =
                     sqlparser::ast::DataType::Blob(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
+            }
+            sqlparser::ast::DataType::TinyBlob => {
+                transformer.transform(self, sqlparser::ast::DataType::TinyBlob)
+            }
+            sqlparser::ast::DataType::MediumBlob => {
+                transformer.transform(self, sqlparser::ast::DataType::MediumBlob)
+            }
+            sqlparser::ast::DataType::LongBlob => {
+                transformer.transform(self, sqlparser::ast::DataType::LongBlob)
             }
             sqlparser::ast::DataType::Bytes(field0) => {
                 let transformed =
@@ -2044,8 +2161,10 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::DataType {
             sqlparser::ast::DataType::Float8 => {
                 transformer.transform(self, sqlparser::ast::DataType::Float8)
             }
-            sqlparser::ast::DataType::Double => {
-                transformer.transform(self, sqlparser::ast::DataType::Double)
+            sqlparser::ast::DataType::Double(field0) => {
+                let transformed =
+                    sqlparser::ast::DataType::Double(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
             }
             sqlparser::ast::DataType::DoublePrecision => {
                 transformer.transform(self, sqlparser::ast::DataType::DoublePrecision)
@@ -2103,6 +2222,15 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::DataType {
             sqlparser::ast::DataType::Text => {
                 transformer.transform(self, sqlparser::ast::DataType::Text)
             }
+            sqlparser::ast::DataType::TinyText => {
+                transformer.transform(self, sqlparser::ast::DataType::TinyText)
+            }
+            sqlparser::ast::DataType::MediumText => {
+                transformer.transform(self, sqlparser::ast::DataType::MediumText)
+            }
+            sqlparser::ast::DataType::LongText => {
+                transformer.transform(self, sqlparser::ast::DataType::LongText)
+            }
             sqlparser::ast::DataType::String(field0) => {
                 let transformed =
                     sqlparser::ast::DataType::String(field0.apply_transform(transformer)?);
@@ -2115,6 +2243,16 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::DataType {
             }
             sqlparser::ast::DataType::Bytea => {
                 transformer.transform(self, sqlparser::ast::DataType::Bytea)
+            }
+            sqlparser::ast::DataType::Bit(field0) => {
+                let transformed =
+                    sqlparser::ast::DataType::Bit(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::DataType::BitVarying(field0) => {
+                let transformed =
+                    sqlparser::ast::DataType::BitVarying(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
             }
             sqlparser::ast::DataType::Custom(field0, field1) => {
                 let transformed = sqlparser::ast::DataType::Custom(
@@ -2145,9 +2283,11 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::DataType {
                     sqlparser::ast::DataType::Nested(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::DataType::Enum(field0) => {
-                let transformed =
-                    sqlparser::ast::DataType::Enum(field0.apply_transform(transformer)?);
+            sqlparser::ast::DataType::Enum(field0, field1) => {
+                let transformed = sqlparser::ast::DataType::Enum(
+                    field0.apply_transform(transformer)?,
+                    field1.apply_transform(transformer)?,
+                );
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::DataType::Set(field0) => {
@@ -2182,6 +2322,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::DataType {
             }
             sqlparser::ast::DataType::Trigger => {
                 transformer.transform(self, sqlparser::ast::DataType::Trigger)
+            }
+            sqlparser::ast::DataType::AnyType => {
+                transformer.transform(self, sqlparser::ast::DataType::AnyType)
             }
         }
     }
@@ -2600,6 +2743,28 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::EmptyMatchesMode {
     }
 }
 #[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::EnumMember {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::EnumMember::Name(field0) => {
+                let transformed =
+                    sqlparser::ast::EnumMember::Name(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::EnumMember::NamedValue(field0, field1) => {
+                let transformed = sqlparser::ast::EnumMember::NamedValue(
+                    field0.apply_transform(transformer)?,
+                    field1.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ExactNumberInfo {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -2678,6 +2843,13 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Expr {
             sqlparser::ast::Expr::CompoundIdentifier(field0) => {
                 let transformed =
                     sqlparser::ast::Expr::CompoundIdentifier(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::Expr::CompoundFieldAccess { root, access_chain } => {
+                let transformed = sqlparser::ast::Expr::CompoundFieldAccess {
+                    root: root.apply_transform(transformer)?,
+                    access_chain: access_chain.apply_transform(transformer)?,
+                };
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::Expr::JsonAccess { value, path } => {
@@ -3046,16 +3218,14 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Expr {
                 };
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Expr::MapAccess { column, keys } => {
-                let transformed = sqlparser::ast::Expr::MapAccess {
-                    column: column.apply_transform(transformer)?,
-                    keys: keys.apply_transform(transformer)?,
-                };
-                transformer.transform(self, transformed)
-            }
             sqlparser::ast::Expr::Function(field0) => {
                 let transformed =
                     sqlparser::ast::Expr::Function(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::Expr::Method(field0) => {
+                let transformed =
+                    sqlparser::ast::Expr::Method(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::Expr::Case {
@@ -3125,13 +3295,6 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Expr {
                 let transformed = sqlparser::ast::Expr::Map(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Expr::Subscript { expr, subscript } => {
-                let transformed = sqlparser::ast::Expr::Subscript {
-                    expr: expr.apply_transform(transformer)?,
-                    subscript: subscript.apply_transform(transformer)?,
-                };
-                transformer.transform(self, transformed)
-            }
             sqlparser::ast::Expr::Array(field0) => {
                 let transformed = sqlparser::ast::Expr::Array(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
@@ -3153,12 +3316,16 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Expr {
                 };
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Expr::Wildcard => {
-                transformer.transform(self, sqlparser::ast::Expr::Wildcard)
-            }
-            sqlparser::ast::Expr::QualifiedWildcard(field0) => {
+            sqlparser::ast::Expr::Wildcard(field0) => {
                 let transformed =
-                    sqlparser::ast::Expr::QualifiedWildcard(field0.apply_transform(transformer)?);
+                    sqlparser::ast::Expr::Wildcard(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::Expr::QualifiedWildcard(field0, field1) => {
+                let transformed = sqlparser::ast::Expr::QualifiedWildcard(
+                    field0.apply_transform(transformer)?,
+                    field1.apply_transform(transformer)?,
+                );
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::Expr::OuterJoin(field0) => {
@@ -3515,6 +3682,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Function {
     {
         let Self {
             name,
+            uses_odbc_syntax,
             parameters,
             args,
             filter,
@@ -3524,6 +3692,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Function {
         } = self;
         let transformed = Self {
             name: name.apply_transform(transformer)?,
+            uses_odbc_syntax: uses_odbc_syntax.apply_transform(transformer)?,
             parameters: parameters.apply_transform(transformer)?,
             args: args.apply_transform(transformer)?,
             filter: filter.apply_transform(transformer)?,
@@ -3547,6 +3716,18 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::FunctionArg {
                 operator,
             } => {
                 let transformed = sqlparser::ast::FunctionArg::Named {
+                    name: name.apply_transform(transformer)?,
+                    arg: arg.apply_transform(transformer)?,
+                    operator: operator.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::FunctionArg::ExprNamed {
+                name,
+                arg,
+                operator,
+            } => {
+                let transformed = sqlparser::ast::FunctionArg::ExprNamed {
                     name: name.apply_transform(transformer)?,
                     arg: arg.apply_transform(transformer)?,
                     operator: operator.apply_transform(transformer)?,
@@ -3601,6 +3782,12 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::FunctionArgOperator {
             sqlparser::ast::FunctionArgOperator::Assignment => {
                 transformer.transform(self, sqlparser::ast::FunctionArgOperator::Assignment)
             }
+            sqlparser::ast::FunctionArgOperator::Colon => {
+                transformer.transform(self, sqlparser::ast::FunctionArgOperator::Colon)
+            }
+            sqlparser::ast::FunctionArgOperator::Value => {
+                transformer.transform(self, sqlparser::ast::FunctionArgOperator::Value)
+            }
         }
     }
 }
@@ -3643,6 +3830,12 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::FunctionArgumentClause
             }
             sqlparser::ast::FunctionArgumentClause::Separator(field0) => {
                 let transformed = sqlparser::ast::FunctionArgumentClause::Separator(
+                    field0.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::FunctionArgumentClause::JsonNullClause(field0) => {
+                let transformed = sqlparser::ast::FunctionArgumentClause::JsonNullClause(
                     field0.apply_transform(transformer)?,
                 );
                 transformer.transform(self, transformed)
@@ -4052,6 +4245,23 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::HiveIOFormat {
     }
 }
 #[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::HiveLoadDataFormat {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            serde,
+            input_format,
+        } = self;
+        let transformed = Self {
+            serde: serde.apply_transform(transformer)?,
+            input_format: input_format.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::HiveRowDelimiter {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -4107,10 +4317,15 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Ident {
     where
         T: crate::Transform<'ast>,
     {
-        let Self { value, quote_style } = self;
+        let Self {
+            value,
+            quote_style,
+            span,
+        } = self;
         let transformed = Self {
             value: value.apply_transform(transformer)?,
             quote_style: quote_style.apply_transform(transformer)?,
+            span: span.apply_transform(transformer)?,
         };
         transformer.transform(self, transformed)
     }
@@ -4454,6 +4669,11 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::JoinOperator {
             sqlparser::ast::JoinOperator::CrossJoin => {
                 transformer.transform(self, sqlparser::ast::JoinOperator::CrossJoin)
             }
+            sqlparser::ast::JoinOperator::Semi(field0) => {
+                let transformed =
+                    sqlparser::ast::JoinOperator::Semi(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
             sqlparser::ast::JoinOperator::LeftSemi(field0) => {
                 let transformed =
                     sqlparser::ast::JoinOperator::LeftSemi(field0.apply_transform(transformer)?);
@@ -4462,6 +4682,11 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::JoinOperator {
             sqlparser::ast::JoinOperator::RightSemi(field0) => {
                 let transformed =
                     sqlparser::ast::JoinOperator::RightSemi(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::JoinOperator::Anti(field0) => {
+                let transformed =
+                    sqlparser::ast::JoinOperator::Anti(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::JoinOperator::LeftAnti(field0) => {
@@ -4489,6 +4714,22 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::JoinOperator {
                     constraint: constraint.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::JsonNullClause {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::JsonNullClause::NullOnNull => {
+                transformer.transform(self, sqlparser::ast::JsonNullClause::NullOnNull)
+            }
+            sqlparser::ast::JsonNullClause::AbsentOnNull => {
+                transformer.transform(self, sqlparser::ast::JsonNullClause::AbsentOnNull)
             }
         }
     }
@@ -4729,25 +4970,6 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::LockClause {
     }
 }
 #[automatically_derived]
-impl<'ast> crate::Transformable<'ast> for sqlparser::ast::LockTable {
-    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
-    where
-        T: crate::Transform<'ast>,
-    {
-        let Self {
-            table,
-            alias,
-            lock_type,
-        } = self;
-        let transformed = Self {
-            table: table.apply_transform(transformer)?,
-            alias: alias.apply_transform(transformer)?,
-            lock_type: lock_type.apply_transform(transformer)?,
-        };
-        transformer.transform(self, transformed)
-    }
-}
-#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::LockTableType {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -4766,6 +4988,69 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::LockTableType {
                 };
                 transformer.transform(self, transformed)
             }
+            sqlparser::ast::LockTableType::AccessShare => {
+                transformer.transform(self, sqlparser::ast::LockTableType::AccessShare)
+            }
+            sqlparser::ast::LockTableType::RowShare => {
+                transformer.transform(self, sqlparser::ast::LockTableType::RowShare)
+            }
+            sqlparser::ast::LockTableType::RowExclusive => {
+                transformer.transform(self, sqlparser::ast::LockTableType::RowExclusive)
+            }
+            sqlparser::ast::LockTableType::ShareUpdateExclusive => {
+                transformer.transform(self, sqlparser::ast::LockTableType::ShareUpdateExclusive)
+            }
+            sqlparser::ast::LockTableType::Share => {
+                transformer.transform(self, sqlparser::ast::LockTableType::Share)
+            }
+            sqlparser::ast::LockTableType::ShareRowExclusive => {
+                transformer.transform(self, sqlparser::ast::LockTableType::ShareRowExclusive)
+            }
+            sqlparser::ast::LockTableType::Exclusive => {
+                transformer.transform(self, sqlparser::ast::LockTableType::Exclusive)
+            }
+            sqlparser::ast::LockTableType::AccessExclusive => {
+                transformer.transform(self, sqlparser::ast::LockTableType::AccessExclusive)
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::LockTables {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::LockTables::MySql {
+                pluralized_table_keyword,
+                tables,
+            } => {
+                let transformed = sqlparser::ast::LockTables::MySql {
+                    pluralized_table_keyword: pluralized_table_keyword
+                        .apply_transform(transformer)?,
+                    tables: tables.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::LockTables::Postgres {
+                tables,
+                lock_mode,
+                has_table_keyword,
+                only,
+                no_wait,
+            } => {
+                let transformed = sqlparser::ast::LockTables::Postgres {
+                    tables: tables.apply_transform(transformer)?,
+                    lock_mode: lock_mode.apply_transform(transformer)?,
+                    has_table_keyword: has_table_keyword.apply_transform(transformer)?,
+                    only: only.apply_transform(transformer)?,
+                    no_wait: no_wait.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
+            _ => unreachable!(),
         }
     }
 }
@@ -4830,36 +5115,6 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Map {
             entries: entries.apply_transform(transformer)?,
         };
         transformer.transform(self, transformed)
-    }
-}
-#[automatically_derived]
-impl<'ast> crate::Transformable<'ast> for sqlparser::ast::MapAccessKey {
-    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
-    where
-        T: crate::Transform<'ast>,
-    {
-        let Self { key, syntax } = self;
-        let transformed = Self {
-            key: key.apply_transform(transformer)?,
-            syntax: syntax.apply_transform(transformer)?,
-        };
-        transformer.transform(self, transformed)
-    }
-}
-#[automatically_derived]
-impl<'ast> crate::Transformable<'ast> for sqlparser::ast::MapAccessSyntax {
-    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
-    where
-        T: crate::Transform<'ast>,
-    {
-        match self {
-            sqlparser::ast::MapAccessSyntax::Bracket => {
-                transformer.transform(self, sqlparser::ast::MapAccessSyntax::Bracket)
-            }
-            sqlparser::ast::MapAccessSyntax::Period => {
-                transformer.transform(self, sqlparser::ast::MapAccessSyntax::Period)
-            }
-        }
     }
 }
 #[automatically_derived]
@@ -5063,6 +5318,20 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::MergeInsertKind {
     }
 }
 #[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Method {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { expr, method_chain } = self;
+        let transformed = Self {
+            expr: expr.apply_transform(transformer)?,
+            method_chain: method_chain.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::MinMaxValue {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -5100,6 +5369,25 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::MySQLColumnPosition {
                 transformer.transform(self, transformed)
             }
         }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::MySqlTableLock {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            table,
+            alias,
+            lock_type,
+        } = self;
+        let transformed = Self {
+            table: table.apply_transform(transformer)?,
+            alias: alias.apply_transform(transformer)?,
+            lock_type: lock_type.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
     }
 }
 #[automatically_derived]
@@ -5185,6 +5473,25 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::NullTreatment {
             }
             sqlparser::ast::NullTreatment::RespectNulls => {
                 transformer.transform(self, sqlparser::ast::NullTreatment::RespectNulls)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::NullsDistinctOption {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::NullsDistinctOption::None => {
+                transformer.transform(self, sqlparser::ast::NullsDistinctOption::None)
+            }
+            sqlparser::ast::NullsDistinctOption::Distinct => {
+                transformer.transform(self, sqlparser::ast::NullsDistinctOption::Distinct)
+            }
+            sqlparser::ast::NullsDistinctOption::NotDistinct => {
+                transformer.transform(self, sqlparser::ast::NullsDistinctOption::NotDistinct)
             }
         }
     }
@@ -5345,6 +5652,27 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::OnInsert {
             }
             _ => unreachable!(),
         }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::OpenJsonTableColumn {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            name,
+            r#type,
+            path,
+            as_json,
+        } = self;
+        let transformed = Self {
+            name: name.apply_transform(transformer)?,
+            r#type: r#type.apply_transform(transformer)?,
+            path: path.apply_transform(transformer)?,
+            as_json: as_json.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
     }
 }
 #[automatically_derived]
@@ -5656,6 +5984,20 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::RenameSelectItem {
     }
 }
 #[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::RenameTable {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { old_name, new_name } = self;
+        let transformed = Self {
+            old_name: old_name.apply_transform(transformer)?,
+            new_name: new_name.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::RepetitionQuantifier {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -5895,6 +6237,27 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::SearchModifier {
     }
 }
 #[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::SecondaryRoles {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::SecondaryRoles::All => {
+                transformer.transform(self, sqlparser::ast::SecondaryRoles::All)
+            }
+            sqlparser::ast::SecondaryRoles::None => {
+                transformer.transform(self, sqlparser::ast::SecondaryRoles::None)
+            }
+            sqlparser::ast::SecondaryRoles::List(field0) => {
+                let transformed =
+                    sqlparser::ast::SecondaryRoles::List(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::SecretOption {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -5915,6 +6278,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Select {
         T: crate::Transform<'ast>,
     {
         let Self {
+            select_token,
             distinct,
             top,
             top_before_distinct,
@@ -5936,6 +6300,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Select {
             connect_by,
         } = self;
         let transformed = Self {
+            select_token: select_token.apply_transform(transformer)?,
             distinct: distinct.apply_transform(transformer)?,
             top: top.apply_transform(transformer)?,
             top_before_distinct: top_before_distinct.apply_transform(transformer)?,
@@ -6195,22 +6560,6 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Setting {
     }
 }
 #[automatically_derived]
-impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowClause {
-    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
-    where
-        T: crate::Transform<'ast>,
-    {
-        match self {
-            sqlparser::ast::ShowClause::IN => {
-                transformer.transform(self, sqlparser::ast::ShowClause::IN)
-            }
-            sqlparser::ast::ShowClause::FROM => {
-                transformer.transform(self, sqlparser::ast::ShowClause::FROM)
-            }
-        }
-    }
-}
-#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowCreateObject {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -6269,6 +6618,111 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowStatementFilter {
                 transformer.transform(self, transformed)
             }
         }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowStatementFilterPosition {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::ShowStatementFilterPosition::Infix(field0) => {
+                let transformed = sqlparser::ast::ShowStatementFilterPosition::Infix(
+                    field0.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::ShowStatementFilterPosition::Suffix(field0) => {
+                let transformed = sqlparser::ast::ShowStatementFilterPosition::Suffix(
+                    field0.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowStatementIn {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            clause,
+            parent_type,
+            parent_name,
+        } = self;
+        let transformed = Self {
+            clause: clause.apply_transform(transformer)?,
+            parent_type: parent_type.apply_transform(transformer)?,
+            parent_name: parent_name.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowStatementInClause {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::ShowStatementInClause::IN => {
+                transformer.transform(self, sqlparser::ast::ShowStatementInClause::IN)
+            }
+            sqlparser::ast::ShowStatementInClause::FROM => {
+                transformer.transform(self, sqlparser::ast::ShowStatementInClause::FROM)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowStatementInParentType {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::ShowStatementInParentType::Account => {
+                transformer.transform(self, sqlparser::ast::ShowStatementInParentType::Account)
+            }
+            sqlparser::ast::ShowStatementInParentType::Database => {
+                transformer.transform(self, sqlparser::ast::ShowStatementInParentType::Database)
+            }
+            sqlparser::ast::ShowStatementInParentType::Schema => {
+                transformer.transform(self, sqlparser::ast::ShowStatementInParentType::Schema)
+            }
+            sqlparser::ast::ShowStatementInParentType::Table => {
+                transformer.transform(self, sqlparser::ast::ShowStatementInParentType::Table)
+            }
+            sqlparser::ast::ShowStatementInParentType::View => {
+                transformer.transform(self, sqlparser::ast::ShowStatementInParentType::View)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::ShowStatementOptions {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            show_in,
+            starts_with,
+            limit,
+            limit_from,
+            filter_position,
+        } = self;
+        let transformed = Self {
+            show_in: show_in.apply_transform(transformer)?,
+            starts_with: starts_with.apply_transform(transformer)?,
+            limit: limit.apply_transform(transformer)?,
+            limit_from: limit_from.apply_transform(transformer)?,
+            filter_position: filter_position.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
     }
 }
 #[automatically_derived]
@@ -6350,6 +6804,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                 cache_metadata,
                 noscan,
                 compute_statistics,
+                has_table_keyword,
             } => {
                 let transformed = sqlparser::ast::Statement::Analyze {
                     table_name: table_name.apply_transform(transformer)?,
@@ -6359,6 +6814,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                     cache_metadata: cache_metadata.apply_transform(transformer)?,
                     noscan: noscan.apply_transform(transformer)?,
                     compute_statistics: compute_statistics.apply_transform(transformer)?,
+                    has_table_keyword: has_table_keyword.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
@@ -6493,6 +6949,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                 from,
                 selection,
                 returning,
+                or,
             } => {
                 let transformed = sqlparser::ast::Statement::Update {
                     table: table.apply_transform(transformer)?,
@@ -6500,6 +6957,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                     from: from.apply_transform(transformer)?,
                     selection: selection.apply_transform(transformer)?,
                     returning: returning.apply_transform(transformer)?,
+                    or: or.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
@@ -6836,6 +7294,18 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                 };
                 transformer.transform(self, transformed)
             }
+            sqlparser::ast::Statement::DropExtension {
+                names,
+                if_exists,
+                cascade_or_restrict,
+            } => {
+                let transformed = sqlparser::ast::Statement::DropExtension {
+                    names: names.apply_transform(transformer)?,
+                    if_exists: if_exists.apply_transform(transformer)?,
+                    cascade_or_restrict: cascade_or_restrict.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
             sqlparser::ast::Statement::Fetch {
                 name,
                 direction,
@@ -6963,56 +7433,66 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
             sqlparser::ast::Statement::ShowColumns {
                 extended,
                 full,
-                table_name,
-                filter,
+                show_options,
             } => {
                 let transformed = sqlparser::ast::Statement::ShowColumns {
                     extended: extended.apply_transform(transformer)?,
                     full: full.apply_transform(transformer)?,
-                    table_name: table_name.apply_transform(transformer)?,
-                    filter: filter.apply_transform(transformer)?,
+                    show_options: show_options.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Statement::ShowDatabases { filter } => {
+            sqlparser::ast::Statement::ShowDatabases {
+                terse,
+                history,
+                show_options,
+            } => {
                 let transformed = sqlparser::ast::Statement::ShowDatabases {
-                    filter: filter.apply_transform(transformer)?,
+                    terse: terse.apply_transform(transformer)?,
+                    history: history.apply_transform(transformer)?,
+                    show_options: show_options.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Statement::ShowSchemas { filter } => {
+            sqlparser::ast::Statement::ShowSchemas {
+                terse,
+                history,
+                show_options,
+            } => {
                 let transformed = sqlparser::ast::Statement::ShowSchemas {
-                    filter: filter.apply_transform(transformer)?,
+                    terse: terse.apply_transform(transformer)?,
+                    history: history.apply_transform(transformer)?,
+                    show_options: show_options.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::Statement::ShowTables {
+                terse,
+                history,
                 extended,
                 full,
-                clause,
-                db_name,
-                filter,
+                external,
+                show_options,
             } => {
                 let transformed = sqlparser::ast::Statement::ShowTables {
+                    terse: terse.apply_transform(transformer)?,
+                    history: history.apply_transform(transformer)?,
                     extended: extended.apply_transform(transformer)?,
                     full: full.apply_transform(transformer)?,
-                    clause: clause.apply_transform(transformer)?,
-                    db_name: db_name.apply_transform(transformer)?,
-                    filter: filter.apply_transform(transformer)?,
+                    external: external.apply_transform(transformer)?,
+                    show_options: show_options.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::Statement::ShowViews {
+                terse,
                 materialized,
-                clause,
-                db_name,
-                filter,
+                show_options,
             } => {
                 let transformed = sqlparser::ast::Statement::ShowViews {
+                    terse: terse.apply_transform(transformer)?,
                     materialized: materialized.apply_transform(transformer)?,
-                    clause: clause.apply_transform(transformer)?,
-                    db_name: db_name.apply_transform(transformer)?,
-                    filter: filter.apply_transform(transformer)?,
+                    show_options: show_options.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
@@ -7030,11 +7510,13 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
             sqlparser::ast::Statement::StartTransaction {
                 modes,
                 begin,
+                transaction,
                 modifier,
             } => {
                 let transformed = sqlparser::ast::Statement::StartTransaction {
                     modes: modes.apply_transform(transformer)?,
                     begin: begin.apply_transform(transformer)?,
+                    transaction: transaction.apply_transform(transformer)?,
                     modifier: modifier.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
@@ -7102,40 +7584,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                 };
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Statement::CreateFunction {
-                or_replace,
-                temporary,
-                if_not_exists,
-                name,
-                args,
-                return_type,
-                function_body,
-                behavior,
-                called_on_null,
-                parallel,
-                using,
-                language,
-                determinism_specifier,
-                options,
-                remote_connection,
-            } => {
-                let transformed = sqlparser::ast::Statement::CreateFunction {
-                    or_replace: or_replace.apply_transform(transformer)?,
-                    temporary: temporary.apply_transform(transformer)?,
-                    if_not_exists: if_not_exists.apply_transform(transformer)?,
-                    name: name.apply_transform(transformer)?,
-                    args: args.apply_transform(transformer)?,
-                    return_type: return_type.apply_transform(transformer)?,
-                    function_body: function_body.apply_transform(transformer)?,
-                    behavior: behavior.apply_transform(transformer)?,
-                    called_on_null: called_on_null.apply_transform(transformer)?,
-                    parallel: parallel.apply_transform(transformer)?,
-                    using: using.apply_transform(transformer)?,
-                    language: language.apply_transform(transformer)?,
-                    determinism_specifier: determinism_specifier.apply_transform(transformer)?,
-                    options: options.apply_transform(transformer)?,
-                    remote_connection: remote_connection.apply_transform(transformer)?,
-                };
+            sqlparser::ast::Statement::CreateFunction(field0) => {
+                let transformed =
+                    sqlparser::ast::Statement::CreateFunction(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::Statement::CreateTrigger {
@@ -7336,6 +7787,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                 analyze,
                 verbose,
                 query_plan,
+                estimate,
                 statement,
                 format,
                 options,
@@ -7345,6 +7797,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                     analyze: analyze.apply_transform(transformer)?,
                     verbose: verbose.apply_transform(transformer)?,
                     query_plan: query_plan.apply_transform(transformer)?,
+                    estimate: estimate.apply_transform(transformer)?,
                     statement: statement.apply_transform(transformer)?,
                     format: format.apply_transform(transformer)?,
                     options: options.apply_transform(transformer)?,
@@ -7441,14 +7894,15 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                 };
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Statement::LockTables { tables } => {
-                let transformed = sqlparser::ast::Statement::LockTables {
-                    tables: tables.apply_transform(transformer)?,
-                };
+            sqlparser::ast::Statement::LockTables(field0) => {
+                let transformed =
+                    sqlparser::ast::Statement::LockTables(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
-            sqlparser::ast::Statement::UnlockTables => {
-                transformer.transform(self, sqlparser::ast::Statement::UnlockTables)
+            sqlparser::ast::Statement::UnlockTables(field0) => {
+                let transformed =
+                    sqlparser::ast::Statement::UnlockTables(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
             }
             sqlparser::ast::Statement::Unload { query, to, with } => {
                 let transformed = sqlparser::ast::Statement::Unload {
@@ -7480,11 +7934,40 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Statement {
                 };
                 transformer.transform(self, transformed)
             }
+            sqlparser::ast::Statement::UNLISTEN { channel } => {
+                let transformed = sqlparser::ast::Statement::UNLISTEN {
+                    channel: channel.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
             sqlparser::ast::Statement::NOTIFY { channel, payload } => {
                 let transformed = sqlparser::ast::Statement::NOTIFY {
                     channel: channel.apply_transform(transformer)?,
                     payload: payload.apply_transform(transformer)?,
                 };
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::Statement::LoadData {
+                local,
+                inpath,
+                overwrite,
+                table_name,
+                partitioned,
+                table_format,
+            } => {
+                let transformed = sqlparser::ast::Statement::LoadData {
+                    local: local.apply_transform(transformer)?,
+                    inpath: inpath.apply_transform(transformer)?,
+                    overwrite: overwrite.apply_transform(transformer)?,
+                    table_name: table_name.apply_transform(transformer)?,
+                    partitioned: partitioned.apply_transform(transformer)?,
+                    table_format: table_format.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::Statement::RenameTable(field0) => {
+                let transformed =
+                    sqlparser::ast::Statement::RenameTable(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
         }
@@ -7597,6 +8080,20 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableAlias {
     }
 }
 #[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableAliasColumnDef {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { name, data_type } = self;
+        let transformed = Self {
+            name: name.apply_transform(transformer)?,
+            data_type: data_type.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableConstraint {
     fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
     where
@@ -7611,6 +8108,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableConstraint {
                 columns,
                 index_options,
                 characteristics,
+                nulls_distinct,
             } => {
                 let transformed = sqlparser::ast::TableConstraint::Unique {
                     name: name.apply_transform(transformer)?,
@@ -7620,6 +8118,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableConstraint {
                     columns: columns.apply_transform(transformer)?,
                     index_options: index_options.apply_transform(transformer)?,
                     characteristics: characteristics.apply_transform(transformer)?,
+                    nulls_distinct: nulls_distinct.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
@@ -7728,6 +8227,8 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableFactor {
                 version,
                 with_ordinality,
                 partitions,
+                json_path,
+                sample,
             } => {
                 let transformed = sqlparser::ast::TableFactor::Table {
                     name: name.apply_transform(transformer)?,
@@ -7737,6 +8238,8 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableFactor {
                     version: version.apply_transform(transformer)?,
                     with_ordinality: with_ordinality.apply_transform(transformer)?,
                     partitions: partitions.apply_transform(transformer)?,
+                    json_path: json_path.apply_transform(transformer)?,
+                    sample: sample.apply_transform(transformer)?,
                 };
                 transformer.transform(self, transformed)
             }
@@ -7796,6 +8299,20 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableFactor {
                 alias,
             } => {
                 let transformed = sqlparser::ast::TableFactor::JsonTable {
+                    json_expr: json_expr.apply_transform(transformer)?,
+                    json_path: json_path.apply_transform(transformer)?,
+                    columns: columns.apply_transform(transformer)?,
+                    alias: alias.apply_transform(transformer)?,
+                };
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::TableFactor::OpenJsonTable {
+                json_expr,
+                json_path,
+                columns,
+                alias,
+            } => {
+                let transformed = sqlparser::ast::TableFactor::OpenJsonTable {
                     json_expr: json_expr.apply_transform(transformer)?,
                     json_path: json_path.apply_transform(transformer)?,
                     columns: columns.apply_transform(transformer)?,
@@ -7910,6 +8427,171 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableOptionsClustered 
                     field0.apply_transform(transformer)?,
                 );
                 transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSample {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            modifier,
+            name,
+            quantity,
+            seed,
+            bucket,
+            offset,
+        } = self;
+        let transformed = Self {
+            modifier: modifier.apply_transform(transformer)?,
+            name: name.apply_transform(transformer)?,
+            quantity: quantity.apply_transform(transformer)?,
+            seed: seed.apply_transform(transformer)?,
+            bucket: bucket.apply_transform(transformer)?,
+            offset: offset.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleBucket {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { bucket, total, on } = self;
+        let transformed = Self {
+            bucket: bucket.apply_transform(transformer)?,
+            total: total.apply_transform(transformer)?,
+            on: on.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleKind {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::TableSampleKind::BeforeTableAlias(field0) => {
+                let transformed = sqlparser::ast::TableSampleKind::BeforeTableAlias(
+                    field0.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::TableSampleKind::AfterTableAlias(field0) => {
+                let transformed = sqlparser::ast::TableSampleKind::AfterTableAlias(
+                    field0.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleMethod {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::TableSampleMethod::Row => {
+                transformer.transform(self, sqlparser::ast::TableSampleMethod::Row)
+            }
+            sqlparser::ast::TableSampleMethod::Bernoulli => {
+                transformer.transform(self, sqlparser::ast::TableSampleMethod::Bernoulli)
+            }
+            sqlparser::ast::TableSampleMethod::System => {
+                transformer.transform(self, sqlparser::ast::TableSampleMethod::System)
+            }
+            sqlparser::ast::TableSampleMethod::Block => {
+                transformer.transform(self, sqlparser::ast::TableSampleMethod::Block)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleModifier {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::TableSampleModifier::Sample => {
+                transformer.transform(self, sqlparser::ast::TableSampleModifier::Sample)
+            }
+            sqlparser::ast::TableSampleModifier::TableSample => {
+                transformer.transform(self, sqlparser::ast::TableSampleModifier::TableSample)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleQuantity {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self {
+            parenthesized,
+            value,
+            unit,
+        } = self;
+        let transformed = Self {
+            parenthesized: parenthesized.apply_transform(transformer)?,
+            value: value.apply_transform(transformer)?,
+            unit: unit.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleSeed {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { modifier, value } = self;
+        let transformed = Self {
+            modifier: modifier.apply_transform(transformer)?,
+            value: value.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleSeedModifier {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::TableSampleSeedModifier::Repeatable => {
+                transformer.transform(self, sqlparser::ast::TableSampleSeedModifier::Repeatable)
+            }
+            sqlparser::ast::TableSampleSeedModifier::Seed => {
+                transformer.transform(self, sqlparser::ast::TableSampleSeedModifier::Seed)
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::TableSampleUnit {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::TableSampleUnit::Rows => {
+                transformer.transform(self, sqlparser::ast::TableSampleUnit::Rows)
+            }
+            sqlparser::ast::TableSampleUnit::Percent => {
+                transformer.transform(self, sqlparser::ast::TableSampleUnit::Percent)
             }
         }
     }
@@ -8341,6 +9023,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::UnaryOperator {
             sqlparser::ast::UnaryOperator::PGAbs => {
                 transformer.transform(self, sqlparser::ast::UnaryOperator::PGAbs)
             }
+            sqlparser::ast::UnaryOperator::BangNot => {
+                transformer.transform(self, sqlparser::ast::UnaryOperator::BangNot)
+            }
         }
     }
 }
@@ -8359,6 +9044,28 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::UnionField {
             field_type: field_type.apply_transform(transformer)?,
         };
         transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::UpdateTableFromKind {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        match self {
+            sqlparser::ast::UpdateTableFromKind::BeforeSet(field0) => {
+                let transformed = sqlparser::ast::UpdateTableFromKind::BeforeSet(
+                    field0.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::UpdateTableFromKind::AfterSet(field0) => {
+                let transformed = sqlparser::ast::UpdateTableFromKind::AfterSet(
+                    field0.apply_transform(transformer)?,
+                );
+                transformer.transform(self, transformed)
+            }
+        }
     }
 }
 #[automatically_derived]
@@ -8385,6 +9092,15 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::Use {
             sqlparser::ast::Use::Warehouse(field0) => {
                 let transformed =
                     sqlparser::ast::Use::Warehouse(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::Use::Role(field0) => {
+                let transformed = sqlparser::ast::Use::Role(field0.apply_transform(transformer)?);
+                transformer.transform(self, transformed)
+            }
+            sqlparser::ast::Use::SecondaryRoles(field0) => {
+                let transformed =
+                    sqlparser::ast::Use::SecondaryRoles(field0.apply_transform(transformer)?);
                 transformer.transform(self, transformed)
             }
             sqlparser::ast::Use::Object(field0) => {
@@ -8634,6 +9350,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::WildcardAdditionalOpti
         T: crate::Transform<'ast>,
     {
         let Self {
+            wildcard_token,
             opt_ilike,
             opt_exclude,
             opt_except,
@@ -8641,6 +9358,7 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::WildcardAdditionalOpti
             opt_rename,
         } = self;
         let transformed = Self {
+            wildcard_token: wildcard_token.apply_transform(transformer)?,
             opt_ilike: opt_ilike.apply_transform(transformer)?,
             opt_exclude: opt_exclude.apply_transform(transformer)?,
             opt_except: opt_except.apply_transform(transformer)?,
@@ -8761,10 +9479,12 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::With {
         T: crate::Transform<'ast>,
     {
         let Self {
+            with_token,
             recursive,
             cte_tables,
         } = self;
         let transformed = Self {
+            with_token: with_token.apply_transform(transformer)?,
             recursive: recursive.apply_transform(transformer)?,
             cte_tables: cte_tables.apply_transform(transformer)?,
         };
@@ -8783,6 +9503,17 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::ast::WithFill {
             to: to.apply_transform(transformer)?,
             step: step.apply_transform(transformer)?,
         };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::ast::helpers::attached_token::AttachedToken {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self(field0) = self;
+        let transformed = Self(field0.apply_transform(transformer)?);
         transformer.transform(self, transformed)
     }
 }
@@ -8915,11 +9646,17 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::ABS => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ABS)
             }
+            sqlparser::keywords::Keyword::ABSENT => {
+                transformer.transform(self, sqlparser::keywords::Keyword::ABSENT)
+            }
             sqlparser::keywords::Keyword::ABSOLUTE => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ABSOLUTE)
             }
             sqlparser::keywords::Keyword::ACCESS => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ACCESS)
+            }
+            sqlparser::keywords::Keyword::ACCOUNT => {
+                transformer.transform(self, sqlparser::keywords::Keyword::ACCOUNT)
             }
             sqlparser::keywords::Keyword::ACTION => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ACTION)
@@ -8965,6 +9702,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::ANY => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ANY)
+            }
+            sqlparser::keywords::Keyword::APPLICATION => {
+                transformer.transform(self, sqlparser::keywords::Keyword::APPLICATION)
             }
             sqlparser::keywords::Keyword::APPLY => {
                 transformer.transform(self, sqlparser::keywords::Keyword::APPLY)
@@ -9044,6 +9784,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::BEGIN_PARTITION => {
                 transformer.transform(self, sqlparser::keywords::Keyword::BEGIN_PARTITION)
             }
+            sqlparser::keywords::Keyword::BERNOULLI => {
+                transformer.transform(self, sqlparser::keywords::Keyword::BERNOULLI)
+            }
             sqlparser::keywords::Keyword::BETWEEN => {
                 transformer.transform(self, sqlparser::keywords::Keyword::BETWEEN)
             }
@@ -9062,8 +9805,14 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::BINDING => {
                 transformer.transform(self, sqlparser::keywords::Keyword::BINDING)
             }
+            sqlparser::keywords::Keyword::BIT => {
+                transformer.transform(self, sqlparser::keywords::Keyword::BIT)
+            }
             sqlparser::keywords::Keyword::BLOB => {
                 transformer.transform(self, sqlparser::keywords::Keyword::BLOB)
+            }
+            sqlparser::keywords::Keyword::BLOCK => {
+                transformer.transform(self, sqlparser::keywords::Keyword::BLOCK)
             }
             sqlparser::keywords::Keyword::BLOOMFILTER => {
                 transformer.transform(self, sqlparser::keywords::Keyword::BLOOMFILTER)
@@ -9082,6 +9831,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::BTREE => {
                 transformer.transform(self, sqlparser::keywords::Keyword::BTREE)
+            }
+            sqlparser::keywords::Keyword::BUCKET => {
+                transformer.transform(self, sqlparser::keywords::Keyword::BUCKET)
             }
             sqlparser::keywords::Keyword::BUCKETS => {
                 transformer.transform(self, sqlparser::keywords::Keyword::BUCKETS)
@@ -9184,6 +9936,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::CLUSTERED => {
                 transformer.transform(self, sqlparser::keywords::Keyword::CLUSTERED)
+            }
+            sqlparser::keywords::Keyword::CLUSTERING => {
+                transformer.transform(self, sqlparser::keywords::Keyword::CLUSTERING)
             }
             sqlparser::keywords::Keyword::COALESCE => {
                 transformer.transform(self, sqlparser::keywords::Keyword::COALESCE)
@@ -9543,6 +10298,12 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::ENUM => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ENUM)
             }
+            sqlparser::keywords::Keyword::ENUM16 => {
+                transformer.transform(self, sqlparser::keywords::Keyword::ENUM16)
+            }
+            sqlparser::keywords::Keyword::ENUM8 => {
+                transformer.transform(self, sqlparser::keywords::Keyword::ENUM8)
+            }
             sqlparser::keywords::Keyword::EPHEMERAL => {
                 transformer.transform(self, sqlparser::keywords::Keyword::EPHEMERAL)
             }
@@ -9560,6 +10321,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::ESCAPED => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ESCAPED)
+            }
+            sqlparser::keywords::Keyword::ESTIMATE => {
+                transformer.transform(self, sqlparser::keywords::Keyword::ESTIMATE)
             }
             sqlparser::keywords::Keyword::EVENT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::EVENT)
@@ -9674,6 +10438,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::FLUSH => {
                 transformer.transform(self, sqlparser::keywords::Keyword::FLUSH)
+            }
+            sqlparser::keywords::Keyword::FN => {
+                transformer.transform(self, sqlparser::keywords::Keyword::FN)
             }
             sqlparser::keywords::Keyword::FOLLOWING => {
                 transformer.transform(self, sqlparser::keywords::Keyword::FOLLOWING)
@@ -9857,6 +10624,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::INOUT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::INOUT)
+            }
+            sqlparser::keywords::Keyword::INPATH => {
+                transformer.transform(self, sqlparser::keywords::Keyword::INPATH)
             }
             sqlparser::keywords::Keyword::INPUT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::INPUT)
@@ -10044,6 +10814,12 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::LOGS => {
                 transformer.transform(self, sqlparser::keywords::Keyword::LOGS)
             }
+            sqlparser::keywords::Keyword::LONGBLOB => {
+                transformer.transform(self, sqlparser::keywords::Keyword::LONGBLOB)
+            }
+            sqlparser::keywords::Keyword::LONGTEXT => {
+                transformer.transform(self, sqlparser::keywords::Keyword::LONGTEXT)
+            }
             sqlparser::keywords::Keyword::LOWCARDINALITY => {
                 transformer.transform(self, sqlparser::keywords::Keyword::LOWCARDINALITY)
             }
@@ -10099,8 +10875,14 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::MEASURES => {
                 transformer.transform(self, sqlparser::keywords::Keyword::MEASURES)
             }
+            sqlparser::keywords::Keyword::MEDIUMBLOB => {
+                transformer.transform(self, sqlparser::keywords::Keyword::MEDIUMBLOB)
+            }
             sqlparser::keywords::Keyword::MEDIUMINT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::MEDIUMINT)
+            }
+            sqlparser::keywords::Keyword::MEDIUMTEXT => {
+                transformer.transform(self, sqlparser::keywords::Keyword::MEDIUMTEXT)
             }
             sqlparser::keywords::Keyword::MEMBER => {
                 transformer.transform(self, sqlparser::keywords::Keyword::MEMBER)
@@ -10308,6 +11090,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::OPEN => {
                 transformer.transform(self, sqlparser::keywords::Keyword::OPEN)
+            }
+            sqlparser::keywords::Keyword::OPENJSON => {
+                transformer.transform(self, sqlparser::keywords::Keyword::OPENJSON)
             }
             sqlparser::keywords::Keyword::OPERATOR => {
                 transformer.transform(self, sqlparser::keywords::Keyword::OPERATOR)
@@ -10528,6 +11313,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::REAL => {
                 transformer.transform(self, sqlparser::keywords::Keyword::REAL)
             }
+            sqlparser::keywords::Keyword::RECLUSTER => {
+                transformer.transform(self, sqlparser::keywords::Keyword::RECLUSTER)
+            }
             sqlparser::keywords::Keyword::RECURSIVE => {
                 transformer.transform(self, sqlparser::keywords::Keyword::RECURSIVE)
             }
@@ -10630,6 +11418,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::RESULTSET => {
                 transformer.transform(self, sqlparser::keywords::Keyword::RESULTSET)
             }
+            sqlparser::keywords::Keyword::RESUME => {
+                transformer.transform(self, sqlparser::keywords::Keyword::RESUME)
+            }
             sqlparser::keywords::Keyword::RETAIN => {
                 transformer.transform(self, sqlparser::keywords::Keyword::RETAIN)
             }
@@ -10653,6 +11444,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::ROLE => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ROLE)
+            }
+            sqlparser::keywords::Keyword::ROLES => {
+                transformer.transform(self, sqlparser::keywords::Keyword::ROLES)
             }
             sqlparser::keywords::Keyword::ROLLBACK => {
                 transformer.transform(self, sqlparser::keywords::Keyword::ROLLBACK)
@@ -10687,6 +11481,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::SAFE_CAST => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SAFE_CAST)
             }
+            sqlparser::keywords::Keyword::SAMPLE => {
+                transformer.transform(self, sqlparser::keywords::Keyword::SAMPLE)
+            }
             sqlparser::keywords::Keyword::SAVEPOINT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SAVEPOINT)
             }
@@ -10708,11 +11505,17 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::SECOND => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SECOND)
             }
+            sqlparser::keywords::Keyword::SECONDARY => {
+                transformer.transform(self, sqlparser::keywords::Keyword::SECONDARY)
+            }
             sqlparser::keywords::Keyword::SECRET => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SECRET)
             }
             sqlparser::keywords::Keyword::SECURITY => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SECURITY)
+            }
+            sqlparser::keywords::Keyword::SEED => {
+                transformer.transform(self, sqlparser::keywords::Keyword::SEED)
             }
             sqlparser::keywords::Keyword::SELECT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SELECT)
@@ -10825,6 +11628,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::START => {
                 transformer.transform(self, sqlparser::keywords::Keyword::START)
             }
+            sqlparser::keywords::Keyword::STARTS => {
+                transformer.transform(self, sqlparser::keywords::Keyword::STARTS)
+            }
             sqlparser::keywords::Keyword::STATEMENT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::STATEMENT)
             }
@@ -10888,6 +11694,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::SUPERUSER => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SUPERUSER)
             }
+            sqlparser::keywords::Keyword::SUSPEND => {
+                transformer.transform(self, sqlparser::keywords::Keyword::SUSPEND)
+            }
             sqlparser::keywords::Keyword::SWAP => {
                 transformer.transform(self, sqlparser::keywords::Keyword::SWAP)
             }
@@ -10933,6 +11742,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::TERMINATED => {
                 transformer.transform(self, sqlparser::keywords::Keyword::TERMINATED)
             }
+            sqlparser::keywords::Keyword::TERSE => {
+                transformer.transform(self, sqlparser::keywords::Keyword::TERSE)
+            }
             sqlparser::keywords::Keyword::TEXT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::TEXT)
             }
@@ -10972,8 +11784,14 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             sqlparser::keywords::Keyword::TIMEZONE_REGION => {
                 transformer.transform(self, sqlparser::keywords::Keyword::TIMEZONE_REGION)
             }
+            sqlparser::keywords::Keyword::TINYBLOB => {
+                transformer.transform(self, sqlparser::keywords::Keyword::TINYBLOB)
+            }
             sqlparser::keywords::Keyword::TINYINT => {
                 transformer.transform(self, sqlparser::keywords::Keyword::TINYINT)
+            }
+            sqlparser::keywords::Keyword::TINYTEXT => {
+                transformer.transform(self, sqlparser::keywords::Keyword::TINYTEXT)
             }
             sqlparser::keywords::Keyword::TO => {
                 transformer.transform(self, sqlparser::keywords::Keyword::TO)
@@ -11073,6 +11891,9 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
             }
             sqlparser::keywords::Keyword::UNKNOWN => {
                 transformer.transform(self, sqlparser::keywords::Keyword::UNKNOWN)
+            }
+            sqlparser::keywords::Keyword::UNLISTEN => {
+                transformer.transform(self, sqlparser::keywords::Keyword::UNLISTEN)
             }
             sqlparser::keywords::Keyword::UNLOAD => {
                 transformer.transform(self, sqlparser::keywords::Keyword::UNLOAD)
@@ -11240,6 +12061,34 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::keywords::Keyword {
                 transformer.transform(self, sqlparser::keywords::Keyword::ZORDER)
             }
         }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::tokenizer::Location {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { line, column } = self;
+        let transformed = Self {
+            line: line.apply_transform(transformer)?,
+            column: column.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::tokenizer::Span {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { start, end } = self;
+        let transformed = Self {
+            start: start.apply_transform(transformer)?,
+            end: end.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
     }
 }
 #[automatically_derived]
@@ -11578,6 +12427,20 @@ impl<'ast> crate::Transformable<'ast> for sqlparser::tokenizer::Token {
                 transformer.transform(self, transformed)
             }
         }
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqlparser::tokenizer::TokenWithSpan {
+    fn apply_transform<T>(&'ast self, transformer: &mut T) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        let Self { token, span } = self;
+        let transformed = Self {
+            token: token.apply_transform(transformer)?,
+            span: span.apply_transform(transformer)?,
+        };
+        transformer.transform(self, transformed)
     }
 }
 #[automatically_derived]

--- a/packages/sqltk/src/generated/visitable_impls.rs
+++ b/packages/sqltk/src/generated/visitable_impls.rs
@@ -1,5 +1,31 @@
 use crate::visitable_impls::visit;
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::AccessExpr {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::AccessExpr::Dot(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::AccessExpr::Subscript(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::AccessExpr {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::Action {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -427,6 +453,12 @@ impl crate::Visitable for sqlparser::ast::AlterTableOperation {
                     sqlparser::ast::AlterTableOperation::OwnerTo { new_owner } => {
                         new_owner.accept(visitor)?;
                     }
+                    sqlparser::ast::AlterTableOperation::ClusterBy { exprs } => {
+                        exprs.accept(visitor)?;
+                    }
+                    sqlparser::ast::AlterTableOperation::DropClusteringKey => {}
+                    sqlparser::ast::AlterTableOperation::SuspendRecluster => {}
+                    sqlparser::ast::AlterTableOperation::ResumeRecluster => {}
                 }
                 std::ops::ControlFlow::Continue(())
             },
@@ -604,6 +636,28 @@ impl crate::Visitable for sqlparser::ast::AttachDuckDBDatabaseOption {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::AttachDuckDBDatabaseOption {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::BeginTransactionKind {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::BeginTransactionKind::Transaction => {}
+                    sqlparser::ast::BeginTransactionKind::Work => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::BeginTransactionKind {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::BinaryOperator {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -1096,6 +1150,10 @@ impl crate::Visitable for sqlparser::ast::CommentObject {
                     sqlparser::ast::CommentObject::Column => {}
                     sqlparser::ast::CommentObject::Table => {}
                     sqlparser::ast::CommentObject::Extension => {}
+                    sqlparser::ast::CommentObject::Schema => {}
+                    sqlparser::ast::CommentObject::Database => {}
+                    sqlparser::ast::CommentObject::User => {}
+                    sqlparser::ast::CommentObject::Role => {}
                 }
                 std::ops::ControlFlow::Continue(())
             },
@@ -1369,6 +1427,39 @@ impl crate::Visitable for sqlparser::ast::CopyTarget {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::CopyTarget {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::CreateFunction {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.or_replace.accept(visitor)?;
+                self.temporary.accept(visitor)?;
+                self.if_not_exists.accept(visitor)?;
+                self.name.accept(visitor)?;
+                self.args.accept(visitor)?;
+                self.return_type.accept(visitor)?;
+                self.function_body.accept(visitor)?;
+                self.behavior.accept(visitor)?;
+                self.called_on_null.accept(visitor)?;
+                self.parallel.accept(visitor)?;
+                self.using.accept(visitor)?;
+                self.language.accept(visitor)?;
+                self.determinism_specifier.accept(visitor)?;
+                self.options.accept(visitor)?;
+                self.remote_connection.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::CreateFunction {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::CreateFunctionBody {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -1605,6 +1696,7 @@ impl crate::Visitable for sqlparser::ast::Cte {
                 self.query.accept(visitor)?;
                 self.from.accept(visitor)?;
                 self.materialized.accept(visitor)?;
+                self.closing_paren_token.accept(visitor)?;
                 std::ops::ControlFlow::Continue(())
             },
         )
@@ -1683,6 +1775,9 @@ impl crate::Visitable for sqlparser::ast::DataType {
                     sqlparser::ast::DataType::Blob(field0) => {
                         field0.accept(visitor)?;
                     }
+                    sqlparser::ast::DataType::TinyBlob => {}
+                    sqlparser::ast::DataType::MediumBlob => {}
+                    sqlparser::ast::DataType::LongBlob => {}
                     sqlparser::ast::DataType::Bytes(field0) => {
                         field0.accept(visitor)?;
                     }
@@ -1774,7 +1869,9 @@ impl crate::Visitable for sqlparser::ast::DataType {
                     sqlparser::ast::DataType::Float64 => {}
                     sqlparser::ast::DataType::Real => {}
                     sqlparser::ast::DataType::Float8 => {}
-                    sqlparser::ast::DataType::Double => {}
+                    sqlparser::ast::DataType::Double(field0) => {
+                        field0.accept(visitor)?;
+                    }
                     sqlparser::ast::DataType::DoublePrecision => {}
                     sqlparser::ast::DataType::Bool => {}
                     sqlparser::ast::DataType::Boolean => {}
@@ -1800,6 +1897,9 @@ impl crate::Visitable for sqlparser::ast::DataType {
                     sqlparser::ast::DataType::JSONB => {}
                     sqlparser::ast::DataType::Regclass => {}
                     sqlparser::ast::DataType::Text => {}
+                    sqlparser::ast::DataType::TinyText => {}
+                    sqlparser::ast::DataType::MediumText => {}
+                    sqlparser::ast::DataType::LongText => {}
                     sqlparser::ast::DataType::String(field0) => {
                         field0.accept(visitor)?;
                     }
@@ -1807,6 +1907,12 @@ impl crate::Visitable for sqlparser::ast::DataType {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::DataType::Bytea => {}
+                    sqlparser::ast::DataType::Bit(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::DataType::BitVarying(field0) => {
+                        field0.accept(visitor)?;
+                    }
                     sqlparser::ast::DataType::Custom(field0, field1) => {
                         field0.accept(visitor)?;
                         field1.accept(visitor)?;
@@ -1824,8 +1930,9 @@ impl crate::Visitable for sqlparser::ast::DataType {
                     sqlparser::ast::DataType::Nested(field0) => {
                         field0.accept(visitor)?;
                     }
-                    sqlparser::ast::DataType::Enum(field0) => {
+                    sqlparser::ast::DataType::Enum(field0, field1) => {
                         field0.accept(visitor)?;
+                        field1.accept(visitor)?;
                     }
                     sqlparser::ast::DataType::Set(field0) => {
                         field0.accept(visitor)?;
@@ -1845,6 +1952,7 @@ impl crate::Visitable for sqlparser::ast::DataType {
                     }
                     sqlparser::ast::DataType::Unspecified => {}
                     sqlparser::ast::DataType::Trigger => {}
+                    sqlparser::ast::DataType::AnyType => {}
                 }
                 std::ops::ControlFlow::Continue(())
             },
@@ -2247,6 +2355,33 @@ impl crate::Visitable for sqlparser::ast::EmptyMatchesMode {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::EmptyMatchesMode {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::EnumMember {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::EnumMember::Name(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::EnumMember::NamedValue(field0, field1) => {
+                        field0.accept(visitor)?;
+                        field1.accept(visitor)?;
+                    }
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::EnumMember {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::ExactNumberInfo {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -2337,6 +2472,10 @@ impl crate::Visitable for sqlparser::ast::Expr {
                     }
                     sqlparser::ast::Expr::CompoundIdentifier(field0) => {
                         field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::Expr::CompoundFieldAccess { root, access_chain } => {
+                        root.accept(visitor)?;
+                        access_chain.accept(visitor)?;
                     }
                     sqlparser::ast::Expr::JsonAccess { value, path } => {
                         value.accept(visitor)?;
@@ -2598,11 +2737,10 @@ impl crate::Visitable for sqlparser::ast::Expr {
                         data_type.accept(visitor)?;
                         value.accept(visitor)?;
                     }
-                    sqlparser::ast::Expr::MapAccess { column, keys } => {
-                        column.accept(visitor)?;
-                        keys.accept(visitor)?;
-                    }
                     sqlparser::ast::Expr::Function(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::Expr::Method(field0) => {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::Expr::Case {
@@ -2649,10 +2787,6 @@ impl crate::Visitable for sqlparser::ast::Expr {
                     sqlparser::ast::Expr::Map(field0) => {
                         field0.accept(visitor)?;
                     }
-                    sqlparser::ast::Expr::Subscript { expr, subscript } => {
-                        expr.accept(visitor)?;
-                        subscript.accept(visitor)?;
-                    }
                     sqlparser::ast::Expr::Array(field0) => {
                         field0.accept(visitor)?;
                     }
@@ -2668,9 +2802,12 @@ impl crate::Visitable for sqlparser::ast::Expr {
                         match_value.accept(visitor)?;
                         opt_search_modifier.accept(visitor)?;
                     }
-                    sqlparser::ast::Expr::Wildcard => {}
-                    sqlparser::ast::Expr::QualifiedWildcard(field0) => {
+                    sqlparser::ast::Expr::Wildcard(field0) => {
                         field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::Expr::QualifiedWildcard(field0, field1) => {
+                        field0.accept(visitor)?;
+                        field1.accept(visitor)?;
                     }
                     sqlparser::ast::Expr::OuterJoin(field0) => {
                         field0.accept(visitor)?;
@@ -3033,6 +3170,7 @@ impl crate::Visitable for sqlparser::ast::Function {
             #[allow(unused_variables)]
             |visitor| {
                 self.name.accept(visitor)?;
+                self.uses_odbc_syntax.accept(visitor)?;
                 self.parameters.accept(visitor)?;
                 self.args.accept(visitor)?;
                 self.filter.accept(visitor)?;
@@ -3059,6 +3197,15 @@ impl crate::Visitable for sqlparser::ast::FunctionArg {
             |visitor| {
                 match self {
                     sqlparser::ast::FunctionArg::Named {
+                        name,
+                        arg,
+                        operator,
+                    } => {
+                        name.accept(visitor)?;
+                        arg.accept(visitor)?;
+                        operator.accept(visitor)?;
+                    }
+                    sqlparser::ast::FunctionArg::ExprNamed {
                         name,
                         arg,
                         operator,
@@ -3120,6 +3267,8 @@ impl crate::Visitable for sqlparser::ast::FunctionArgOperator {
                     sqlparser::ast::FunctionArgOperator::Equals => {}
                     sqlparser::ast::FunctionArgOperator::RightArrow => {}
                     sqlparser::ast::FunctionArgOperator::Assignment => {}
+                    sqlparser::ast::FunctionArgOperator::Colon => {}
+                    sqlparser::ast::FunctionArgOperator::Value => {}
                 }
                 std::ops::ControlFlow::Continue(())
             },
@@ -3156,6 +3305,9 @@ impl crate::Visitable for sqlparser::ast::FunctionArgumentClause {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::FunctionArgumentClause::Separator(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::FunctionArgumentClause::JsonNullClause(field0) => {
                         field0.accept(visitor)?;
                     }
                 }
@@ -3631,6 +3783,26 @@ impl crate::Visitable for sqlparser::ast::HiveIOFormat {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::HiveIOFormat {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::HiveLoadDataFormat {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.serde.accept(visitor)?;
+                self.input_format.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::HiveLoadDataFormat {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::HiveRowDelimiter {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -3709,6 +3881,7 @@ impl crate::Visitable for sqlparser::ast::Ident {
             |visitor| {
                 self.value.accept(visitor)?;
                 self.quote_style.accept(visitor)?;
+                self.span.accept(visitor)?;
                 std::ops::ControlFlow::Continue(())
             },
         )
@@ -4107,10 +4280,16 @@ impl crate::Visitable for sqlparser::ast::JoinOperator {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::JoinOperator::CrossJoin => {}
+                    sqlparser::ast::JoinOperator::Semi(field0) => {
+                        field0.accept(visitor)?;
+                    }
                     sqlparser::ast::JoinOperator::LeftSemi(field0) => {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::JoinOperator::RightSemi(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::JoinOperator::Anti(field0) => {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::JoinOperator::LeftAnti(field0) => {
@@ -4136,6 +4315,28 @@ impl crate::Visitable for sqlparser::ast::JoinOperator {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::JoinOperator {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::JsonNullClause {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::JsonNullClause::NullOnNull => {}
+                    sqlparser::ast::JsonNullClause::AbsentOnNull => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::JsonNullClause {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::JsonPath {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -4415,27 +4616,6 @@ impl crate::Visitable for sqlparser::ast::LockClause {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::LockClause {}
 #[automatically_derived]
-impl crate::Visitable for sqlparser::ast::LockTable {
-    fn accept<'ast, V: crate::Visitor<'ast>>(
-        &'ast self,
-        visitor: &mut V,
-    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
-        visit(
-            self,
-            visitor,
-            #[allow(unused_variables)]
-            |visitor| {
-                self.table.accept(visitor)?;
-                self.alias.accept(visitor)?;
-                self.lock_type.accept(visitor)?;
-                std::ops::ControlFlow::Continue(())
-            },
-        )
-    }
-}
-#[automatically_derived]
-impl crate::Semantic for sqlparser::ast::LockTable {}
-#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::LockTableType {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -4453,6 +4633,15 @@ impl crate::Visitable for sqlparser::ast::LockTableType {
                     sqlparser::ast::LockTableType::Write { low_priority } => {
                         low_priority.accept(visitor)?;
                     }
+                    sqlparser::ast::LockTableType::AccessShare => {}
+                    sqlparser::ast::LockTableType::RowShare => {}
+                    sqlparser::ast::LockTableType::RowExclusive => {}
+                    sqlparser::ast::LockTableType::ShareUpdateExclusive => {}
+                    sqlparser::ast::LockTableType::Share => {}
+                    sqlparser::ast::LockTableType::ShareRowExclusive => {}
+                    sqlparser::ast::LockTableType::Exclusive => {}
+                    sqlparser::ast::LockTableType::AccessExclusive => {}
+                    _ => unreachable!(),
                 }
                 std::ops::ControlFlow::Continue(())
             },
@@ -4461,6 +4650,47 @@ impl crate::Visitable for sqlparser::ast::LockTableType {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::LockTableType {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::LockTables {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::LockTables::MySql {
+                        pluralized_table_keyword,
+                        tables,
+                    } => {
+                        pluralized_table_keyword.accept(visitor)?;
+                        tables.accept(visitor)?;
+                    }
+                    sqlparser::ast::LockTables::Postgres {
+                        tables,
+                        lock_mode,
+                        has_table_keyword,
+                        only,
+                        no_wait,
+                    } => {
+                        tables.accept(visitor)?;
+                        lock_mode.accept(visitor)?;
+                        has_table_keyword.accept(visitor)?;
+                        only.accept(visitor)?;
+                        no_wait.accept(visitor)?;
+                    }
+                    _ => unreachable!(),
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::LockTables {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::LockType {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -4548,48 +4778,6 @@ impl crate::Visitable for sqlparser::ast::Map {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::Map {}
-#[automatically_derived]
-impl crate::Visitable for sqlparser::ast::MapAccessKey {
-    fn accept<'ast, V: crate::Visitor<'ast>>(
-        &'ast self,
-        visitor: &mut V,
-    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
-        visit(
-            self,
-            visitor,
-            #[allow(unused_variables)]
-            |visitor| {
-                self.key.accept(visitor)?;
-                self.syntax.accept(visitor)?;
-                std::ops::ControlFlow::Continue(())
-            },
-        )
-    }
-}
-#[automatically_derived]
-impl crate::Semantic for sqlparser::ast::MapAccessKey {}
-#[automatically_derived]
-impl crate::Visitable for sqlparser::ast::MapAccessSyntax {
-    fn accept<'ast, V: crate::Visitor<'ast>>(
-        &'ast self,
-        visitor: &mut V,
-    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
-        visit(
-            self,
-            visitor,
-            #[allow(unused_variables)]
-            |visitor| {
-                match self {
-                    sqlparser::ast::MapAccessSyntax::Bracket => {}
-                    sqlparser::ast::MapAccessSyntax::Period => {}
-                }
-                std::ops::ControlFlow::Continue(())
-            },
-        )
-    }
-}
-#[automatically_derived]
-impl crate::Semantic for sqlparser::ast::MapAccessSyntax {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::MapEntry {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -4814,6 +5002,26 @@ impl crate::Visitable for sqlparser::ast::MergeInsertKind {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::MergeInsertKind {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::Method {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.expr.accept(visitor)?;
+                self.method_chain.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::Method {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::MinMaxValue {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -4862,6 +5070,27 @@ impl crate::Visitable for sqlparser::ast::MySQLColumnPosition {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::MySQLColumnPosition {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::MySqlTableLock {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.table.accept(visitor)?;
+                self.alias.accept(visitor)?;
+                self.lock_type.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::MySqlTableLock {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::MysqlInsertPriority {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -4975,6 +5204,29 @@ impl crate::Visitable for sqlparser::ast::NullTreatment {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::NullTreatment {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::NullsDistinctOption {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::NullsDistinctOption::None => {}
+                    sqlparser::ast::NullsDistinctOption::Distinct => {}
+                    sqlparser::ast::NullsDistinctOption::NotDistinct => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::NullsDistinctOption {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::ObjectName {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -5160,6 +5412,28 @@ impl crate::Visitable for sqlparser::ast::OnInsert {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::OnInsert {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::OpenJsonTableColumn {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.name.accept(visitor)?;
+                self.r#type.accept(visitor)?;
+                self.path.accept(visitor)?;
+                self.as_json.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::OpenJsonTableColumn {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::OperateFunctionArg {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -5507,6 +5781,26 @@ impl crate::Visitable for sqlparser::ast::RenameSelectItem {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::RenameSelectItem {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::RenameTable {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.old_name.accept(visitor)?;
+                self.new_name.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::RenameTable {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::RepetitionQuantifier {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -5755,6 +6049,31 @@ impl crate::Visitable for sqlparser::ast::SearchModifier {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::SearchModifier {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::SecondaryRoles {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::SecondaryRoles::All => {}
+                    sqlparser::ast::SecondaryRoles::None => {}
+                    sqlparser::ast::SecondaryRoles::List(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::SecondaryRoles {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::SecretOption {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -5786,6 +6105,7 @@ impl crate::Visitable for sqlparser::ast::Select {
             #[allow(unused_variables)]
             |visitor| {
                 self.from.accept(visitor)?;
+                self.select_token.accept(visitor)?;
                 self.distinct.accept(visitor)?;
                 self.top.accept(visitor)?;
                 self.top_before_distinct.accept(visitor)?;
@@ -6051,28 +6371,6 @@ impl crate::Visitable for sqlparser::ast::Setting {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::Setting {}
 #[automatically_derived]
-impl crate::Visitable for sqlparser::ast::ShowClause {
-    fn accept<'ast, V: crate::Visitor<'ast>>(
-        &'ast self,
-        visitor: &mut V,
-    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
-        visit(
-            self,
-            visitor,
-            #[allow(unused_variables)]
-            |visitor| {
-                match self {
-                    sqlparser::ast::ShowClause::IN => {}
-                    sqlparser::ast::ShowClause::FROM => {}
-                }
-                std::ops::ControlFlow::Continue(())
-            },
-        )
-    }
-}
-#[automatically_derived]
-impl crate::Semantic for sqlparser::ast::ShowClause {}
-#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::ShowCreateObject {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -6130,6 +6428,123 @@ impl crate::Visitable for sqlparser::ast::ShowStatementFilter {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::ShowStatementFilter {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::ShowStatementFilterPosition {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::ShowStatementFilterPosition::Infix(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::ShowStatementFilterPosition::Suffix(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::ShowStatementFilterPosition {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::ShowStatementIn {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.clause.accept(visitor)?;
+                self.parent_type.accept(visitor)?;
+                self.parent_name.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::ShowStatementIn {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::ShowStatementInClause {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::ShowStatementInClause::IN => {}
+                    sqlparser::ast::ShowStatementInClause::FROM => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::ShowStatementInClause {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::ShowStatementInParentType {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::ShowStatementInParentType::Account => {}
+                    sqlparser::ast::ShowStatementInParentType::Database => {}
+                    sqlparser::ast::ShowStatementInParentType::Schema => {}
+                    sqlparser::ast::ShowStatementInParentType::Table => {}
+                    sqlparser::ast::ShowStatementInParentType::View => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::ShowStatementInParentType {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::ShowStatementOptions {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.show_in.accept(visitor)?;
+                self.starts_with.accept(visitor)?;
+                self.limit.accept(visitor)?;
+                self.limit_from.accept(visitor)?;
+                self.filter_position.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::ShowStatementOptions {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::SqlOption {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -6214,6 +6629,7 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         cache_metadata,
                         noscan,
                         compute_statistics,
+                        has_table_keyword,
                     } => {
                         table_name.accept(visitor)?;
                         partitions.accept(visitor)?;
@@ -6222,6 +6638,7 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         cache_metadata.accept(visitor)?;
                         noscan.accept(visitor)?;
                         compute_statistics.accept(visitor)?;
+                        has_table_keyword.accept(visitor)?;
                     }
                     sqlparser::ast::Statement::Truncate {
                         table_names,
@@ -6324,12 +6741,14 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         from,
                         selection,
                         returning,
+                        or,
                     } => {
                         table.accept(visitor)?;
                         from.accept(visitor)?;
                         assignments.accept(visitor)?;
                         selection.accept(visitor)?;
                         returning.accept(visitor)?;
+                        or.accept(visitor)?;
                     }
                     sqlparser::ast::Statement::Delete(field0) => {
                         field0.accept(visitor)?;
@@ -6598,6 +7017,15 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         schema.accept(visitor)?;
                         version.accept(visitor)?;
                     }
+                    sqlparser::ast::Statement::DropExtension {
+                        names,
+                        if_exists,
+                        cascade_or_restrict,
+                    } => {
+                        names.accept(visitor)?;
+                        if_exists.accept(visitor)?;
+                        cascade_or_restrict.accept(visitor)?;
+                    }
                     sqlparser::ast::Statement::Fetch {
                         name,
                         direction,
@@ -6686,43 +7114,53 @@ impl crate::Visitable for sqlparser::ast::Statement {
                     sqlparser::ast::Statement::ShowColumns {
                         extended,
                         full,
-                        table_name,
-                        filter,
+                        show_options,
                     } => {
                         extended.accept(visitor)?;
                         full.accept(visitor)?;
-                        table_name.accept(visitor)?;
-                        filter.accept(visitor)?;
+                        show_options.accept(visitor)?;
                     }
-                    sqlparser::ast::Statement::ShowDatabases { filter } => {
-                        filter.accept(visitor)?;
+                    sqlparser::ast::Statement::ShowDatabases {
+                        terse,
+                        history,
+                        show_options,
+                    } => {
+                        terse.accept(visitor)?;
+                        history.accept(visitor)?;
+                        show_options.accept(visitor)?;
                     }
-                    sqlparser::ast::Statement::ShowSchemas { filter } => {
-                        filter.accept(visitor)?;
+                    sqlparser::ast::Statement::ShowSchemas {
+                        terse,
+                        history,
+                        show_options,
+                    } => {
+                        terse.accept(visitor)?;
+                        history.accept(visitor)?;
+                        show_options.accept(visitor)?;
                     }
                     sqlparser::ast::Statement::ShowTables {
+                        terse,
+                        history,
                         extended,
                         full,
-                        clause,
-                        db_name,
-                        filter,
+                        external,
+                        show_options,
                     } => {
+                        terse.accept(visitor)?;
+                        history.accept(visitor)?;
                         extended.accept(visitor)?;
                         full.accept(visitor)?;
-                        clause.accept(visitor)?;
-                        db_name.accept(visitor)?;
-                        filter.accept(visitor)?;
+                        external.accept(visitor)?;
+                        show_options.accept(visitor)?;
                     }
                     sqlparser::ast::Statement::ShowViews {
+                        terse,
                         materialized,
-                        clause,
-                        db_name,
-                        filter,
+                        show_options,
                     } => {
+                        terse.accept(visitor)?;
                         materialized.accept(visitor)?;
-                        clause.accept(visitor)?;
-                        db_name.accept(visitor)?;
-                        filter.accept(visitor)?;
+                        show_options.accept(visitor)?;
                     }
                     sqlparser::ast::Statement::ShowCollation { filter } => {
                         filter.accept(visitor)?;
@@ -6733,10 +7171,12 @@ impl crate::Visitable for sqlparser::ast::Statement {
                     sqlparser::ast::Statement::StartTransaction {
                         modes,
                         begin,
+                        transaction,
                         modifier,
                     } => {
                         modes.accept(visitor)?;
                         begin.accept(visitor)?;
+                        transaction.accept(visitor)?;
                         modifier.accept(visitor)?;
                     }
                     sqlparser::ast::Statement::SetTransaction {
@@ -6784,38 +7224,8 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         location.accept(visitor)?;
                         managed_location.accept(visitor)?;
                     }
-                    sqlparser::ast::Statement::CreateFunction {
-                        or_replace,
-                        temporary,
-                        if_not_exists,
-                        name,
-                        args,
-                        return_type,
-                        function_body,
-                        behavior,
-                        called_on_null,
-                        parallel,
-                        using,
-                        language,
-                        determinism_specifier,
-                        options,
-                        remote_connection,
-                    } => {
-                        or_replace.accept(visitor)?;
-                        temporary.accept(visitor)?;
-                        if_not_exists.accept(visitor)?;
-                        name.accept(visitor)?;
-                        args.accept(visitor)?;
-                        return_type.accept(visitor)?;
-                        function_body.accept(visitor)?;
-                        behavior.accept(visitor)?;
-                        called_on_null.accept(visitor)?;
-                        parallel.accept(visitor)?;
-                        using.accept(visitor)?;
-                        language.accept(visitor)?;
-                        determinism_specifier.accept(visitor)?;
-                        options.accept(visitor)?;
-                        remote_connection.accept(visitor)?;
+                    sqlparser::ast::Statement::CreateFunction(field0) => {
+                        field0.accept(visitor)?;
                     }
                     sqlparser::ast::Statement::CreateTrigger {
                         or_replace,
@@ -6976,6 +7386,7 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         analyze,
                         verbose,
                         query_plan,
+                        estimate,
                         statement,
                         format,
                         options,
@@ -6985,6 +7396,7 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         analyze.accept(visitor)?;
                         verbose.accept(visitor)?;
                         query_plan.accept(visitor)?;
+                        estimate.accept(visitor)?;
                         format.accept(visitor)?;
                         options.accept(visitor)?;
                     }
@@ -7054,10 +7466,12 @@ impl crate::Visitable for sqlparser::ast::Statement {
                         value.accept(visitor)?;
                         is_eq.accept(visitor)?;
                     }
-                    sqlparser::ast::Statement::LockTables { tables } => {
-                        tables.accept(visitor)?;
+                    sqlparser::ast::Statement::LockTables(field0) => {
+                        field0.accept(visitor)?;
                     }
-                    sqlparser::ast::Statement::UnlockTables => {}
+                    sqlparser::ast::Statement::UnlockTables(field0) => {
+                        field0.accept(visitor)?;
+                    }
                     sqlparser::ast::Statement::Unload { query, to, with } => {
                         query.accept(visitor)?;
                         to.accept(visitor)?;
@@ -7079,9 +7493,30 @@ impl crate::Visitable for sqlparser::ast::Statement {
                     sqlparser::ast::Statement::LISTEN { channel } => {
                         channel.accept(visitor)?;
                     }
+                    sqlparser::ast::Statement::UNLISTEN { channel } => {
+                        channel.accept(visitor)?;
+                    }
                     sqlparser::ast::Statement::NOTIFY { channel, payload } => {
                         channel.accept(visitor)?;
                         payload.accept(visitor)?;
+                    }
+                    sqlparser::ast::Statement::LoadData {
+                        local,
+                        inpath,
+                        overwrite,
+                        table_name,
+                        partitioned,
+                        table_format,
+                    } => {
+                        local.accept(visitor)?;
+                        inpath.accept(visitor)?;
+                        overwrite.accept(visitor)?;
+                        table_name.accept(visitor)?;
+                        partitioned.accept(visitor)?;
+                        table_format.accept(visitor)?;
+                    }
+                    sqlparser::ast::Statement::RenameTable(field0) => {
+                        field0.accept(visitor)?;
                     }
                 }
                 std::ops::ControlFlow::Continue(())
@@ -7226,6 +7661,26 @@ impl crate::Visitable for sqlparser::ast::TableAlias {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::TableAlias {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableAliasColumnDef {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.name.accept(visitor)?;
+                self.data_type.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableAliasColumnDef {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::TableConstraint {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -7245,6 +7700,7 @@ impl crate::Visitable for sqlparser::ast::TableConstraint {
                         columns,
                         index_options,
                         characteristics,
+                        nulls_distinct,
                     } => {
                         name.accept(visitor)?;
                         index_name.accept(visitor)?;
@@ -7253,6 +7709,7 @@ impl crate::Visitable for sqlparser::ast::TableConstraint {
                         columns.accept(visitor)?;
                         index_options.accept(visitor)?;
                         characteristics.accept(visitor)?;
+                        nulls_distinct.accept(visitor)?;
                     }
                     sqlparser::ast::TableConstraint::PrimaryKey {
                         name,
@@ -7360,6 +7817,8 @@ impl crate::Visitable for sqlparser::ast::TableFactor {
                         version,
                         with_ordinality,
                         partitions,
+                        json_path,
+                        sample,
                     } => {
                         name.accept(visitor)?;
                         alias.accept(visitor)?;
@@ -7368,6 +7827,8 @@ impl crate::Visitable for sqlparser::ast::TableFactor {
                         version.accept(visitor)?;
                         with_ordinality.accept(visitor)?;
                         partitions.accept(visitor)?;
+                        json_path.accept(visitor)?;
+                        sample.accept(visitor)?;
                     }
                     sqlparser::ast::TableFactor::Derived {
                         lateral,
@@ -7407,6 +7868,17 @@ impl crate::Visitable for sqlparser::ast::TableFactor {
                         with_ordinality.accept(visitor)?;
                     }
                     sqlparser::ast::TableFactor::JsonTable {
+                        json_expr,
+                        json_path,
+                        columns,
+                        alias,
+                    } => {
+                        json_expr.accept(visitor)?;
+                        json_path.accept(visitor)?;
+                        columns.accept(visitor)?;
+                        alias.accept(visitor)?;
+                    }
+                    sqlparser::ast::TableFactor::OpenJsonTable {
                         json_expr,
                         json_path,
                         columns,
@@ -7528,6 +8000,208 @@ impl crate::Visitable for sqlparser::ast::TableOptionsClustered {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::TableOptionsClustered {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSample {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.modifier.accept(visitor)?;
+                self.name.accept(visitor)?;
+                self.quantity.accept(visitor)?;
+                self.seed.accept(visitor)?;
+                self.bucket.accept(visitor)?;
+                self.offset.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSample {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleBucket {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.bucket.accept(visitor)?;
+                self.total.accept(visitor)?;
+                self.on.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleBucket {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleKind {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::TableSampleKind::BeforeTableAlias(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::TableSampleKind::AfterTableAlias(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleKind {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleMethod {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::TableSampleMethod::Row => {}
+                    sqlparser::ast::TableSampleMethod::Bernoulli => {}
+                    sqlparser::ast::TableSampleMethod::System => {}
+                    sqlparser::ast::TableSampleMethod::Block => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleMethod {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleModifier {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::TableSampleModifier::Sample => {}
+                    sqlparser::ast::TableSampleModifier::TableSample => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleModifier {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleQuantity {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.parenthesized.accept(visitor)?;
+                self.value.accept(visitor)?;
+                self.unit.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleQuantity {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleSeed {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.modifier.accept(visitor)?;
+                self.value.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleSeed {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleSeedModifier {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::TableSampleSeedModifier::Repeatable => {}
+                    sqlparser::ast::TableSampleSeedModifier::Seed => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleSeedModifier {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::TableSampleUnit {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::TableSampleUnit::Rows => {}
+                    sqlparser::ast::TableSampleUnit::Percent => {}
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::TableSampleUnit {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::TableVersion {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -8040,6 +8714,7 @@ impl crate::Visitable for sqlparser::ast::UnaryOperator {
                     sqlparser::ast::UnaryOperator::PGPostfixFactorial => {}
                     sqlparser::ast::UnaryOperator::PGPrefixFactorial => {}
                     sqlparser::ast::UnaryOperator::PGAbs => {}
+                    sqlparser::ast::UnaryOperator::BangNot => {}
                 }
                 std::ops::ControlFlow::Continue(())
             },
@@ -8069,6 +8744,32 @@ impl crate::Visitable for sqlparser::ast::UnionField {
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::UnionField {}
 #[automatically_derived]
+impl crate::Visitable for sqlparser::ast::UpdateTableFromKind {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqlparser::ast::UpdateTableFromKind::BeforeSet(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::UpdateTableFromKind::AfterSet(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::UpdateTableFromKind {}
+#[automatically_derived]
 impl crate::Visitable for sqlparser::ast::Use {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -8090,6 +8791,12 @@ impl crate::Visitable for sqlparser::ast::Use {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::Use::Warehouse(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::Use::Role(field0) => {
+                        field0.accept(visitor)?;
+                    }
+                    sqlparser::ast::Use::SecondaryRoles(field0) => {
                         field0.accept(visitor)?;
                     }
                     sqlparser::ast::Use::Object(field0) => {
@@ -8327,6 +9034,7 @@ impl crate::Visitable for sqlparser::ast::WildcardAdditionalOptions {
             visitor,
             #[allow(unused_variables)]
             |visitor| {
+                self.wildcard_token.accept(visitor)?;
                 self.opt_ilike.accept(visitor)?;
                 self.opt_exclude.accept(visitor)?;
                 self.opt_except.accept(visitor)?;
@@ -8469,6 +9177,7 @@ impl crate::Visitable for sqlparser::ast::With {
             visitor,
             #[allow(unused_variables)]
             |visitor| {
+                self.with_token.accept(visitor)?;
                 self.recursive.accept(visitor)?;
                 self.cte_tables.accept(visitor)?;
                 std::ops::ControlFlow::Continue(())
@@ -8499,6 +9208,25 @@ impl crate::Visitable for sqlparser::ast::WithFill {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::ast::WithFill {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::ast::helpers::attached_token::AttachedToken {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.0.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::ast::helpers::attached_token::AttachedToken {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::ast::helpers::stmt_data_loading::DataLoadingOption {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -8622,8 +9350,10 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::NoKeyword => {}
                     sqlparser::keywords::Keyword::ABORT => {}
                     sqlparser::keywords::Keyword::ABS => {}
+                    sqlparser::keywords::Keyword::ABSENT => {}
                     sqlparser::keywords::Keyword::ABSOLUTE => {}
                     sqlparser::keywords::Keyword::ACCESS => {}
+                    sqlparser::keywords::Keyword::ACCOUNT => {}
                     sqlparser::keywords::Keyword::ACTION => {}
                     sqlparser::keywords::Keyword::ADD => {}
                     sqlparser::keywords::Keyword::ADMIN => {}
@@ -8639,6 +9369,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::AND => {}
                     sqlparser::keywords::Keyword::ANTI => {}
                     sqlparser::keywords::Keyword::ANY => {}
+                    sqlparser::keywords::Keyword::APPLICATION => {}
                     sqlparser::keywords::Keyword::APPLY => {}
                     sqlparser::keywords::Keyword::ARCHIVE => {}
                     sqlparser::keywords::Keyword::ARE => {}
@@ -8665,19 +9396,23 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::BEGIN => {}
                     sqlparser::keywords::Keyword::BEGIN_FRAME => {}
                     sqlparser::keywords::Keyword::BEGIN_PARTITION => {}
+                    sqlparser::keywords::Keyword::BERNOULLI => {}
                     sqlparser::keywords::Keyword::BETWEEN => {}
                     sqlparser::keywords::Keyword::BIGDECIMAL => {}
                     sqlparser::keywords::Keyword::BIGINT => {}
                     sqlparser::keywords::Keyword::BIGNUMERIC => {}
                     sqlparser::keywords::Keyword::BINARY => {}
                     sqlparser::keywords::Keyword::BINDING => {}
+                    sqlparser::keywords::Keyword::BIT => {}
                     sqlparser::keywords::Keyword::BLOB => {}
+                    sqlparser::keywords::Keyword::BLOCK => {}
                     sqlparser::keywords::Keyword::BLOOMFILTER => {}
                     sqlparser::keywords::Keyword::BOOL => {}
                     sqlparser::keywords::Keyword::BOOLEAN => {}
                     sqlparser::keywords::Keyword::BOTH => {}
                     sqlparser::keywords::Keyword::BROWSE => {}
                     sqlparser::keywords::Keyword::BTREE => {}
+                    sqlparser::keywords::Keyword::BUCKET => {}
                     sqlparser::keywords::Keyword::BUCKETS => {}
                     sqlparser::keywords::Keyword::BY => {}
                     sqlparser::keywords::Keyword::BYPASSRLS => {}
@@ -8712,6 +9447,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::CLOSE => {}
                     sqlparser::keywords::Keyword::CLUSTER => {}
                     sqlparser::keywords::Keyword::CLUSTERED => {}
+                    sqlparser::keywords::Keyword::CLUSTERING => {}
                     sqlparser::keywords::Keyword::COALESCE => {}
                     sqlparser::keywords::Keyword::COLLATE => {}
                     sqlparser::keywords::Keyword::COLLATION => {}
@@ -8830,12 +9566,15 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::ENFORCED => {}
                     sqlparser::keywords::Keyword::ENGINE => {}
                     sqlparser::keywords::Keyword::ENUM => {}
+                    sqlparser::keywords::Keyword::ENUM16 => {}
+                    sqlparser::keywords::Keyword::ENUM8 => {}
                     sqlparser::keywords::Keyword::EPHEMERAL => {}
                     sqlparser::keywords::Keyword::EPOCH => {}
                     sqlparser::keywords::Keyword::EQUALS => {}
                     sqlparser::keywords::Keyword::ERROR => {}
                     sqlparser::keywords::Keyword::ESCAPE => {}
                     sqlparser::keywords::Keyword::ESCAPED => {}
+                    sqlparser::keywords::Keyword::ESTIMATE => {}
                     sqlparser::keywords::Keyword::EVENT => {}
                     sqlparser::keywords::Keyword::EVERY => {}
                     sqlparser::keywords::Keyword::EXCEPT => {}
@@ -8874,6 +9613,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::FLOAT8 => {}
                     sqlparser::keywords::Keyword::FLOOR => {}
                     sqlparser::keywords::Keyword::FLUSH => {}
+                    sqlparser::keywords::Keyword::FN => {}
                     sqlparser::keywords::Keyword::FOLLOWING => {}
                     sqlparser::keywords::Keyword::FOR => {}
                     sqlparser::keywords::Keyword::FORCE => {}
@@ -8935,6 +9675,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::INITIALLY => {}
                     sqlparser::keywords::Keyword::INNER => {}
                     sqlparser::keywords::Keyword::INOUT => {}
+                    sqlparser::keywords::Keyword::INPATH => {}
                     sqlparser::keywords::Keyword::INPUT => {}
                     sqlparser::keywords::Keyword::INPUTFORMAT => {}
                     sqlparser::keywords::Keyword::INSENSITIVE => {}
@@ -8997,6 +9738,8 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::LOCKED => {}
                     sqlparser::keywords::Keyword::LOGIN => {}
                     sqlparser::keywords::Keyword::LOGS => {}
+                    sqlparser::keywords::Keyword::LONGBLOB => {}
+                    sqlparser::keywords::Keyword::LONGTEXT => {}
                     sqlparser::keywords::Keyword::LOWCARDINALITY => {}
                     sqlparser::keywords::Keyword::LOWER => {}
                     sqlparser::keywords::Keyword::LOW_PRIORITY => {}
@@ -9015,7 +9758,9 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::MAXVALUE => {}
                     sqlparser::keywords::Keyword::MAX_DATA_EXTENSION_TIME_IN_DAYS => {}
                     sqlparser::keywords::Keyword::MEASURES => {}
+                    sqlparser::keywords::Keyword::MEDIUMBLOB => {}
                     sqlparser::keywords::Keyword::MEDIUMINT => {}
+                    sqlparser::keywords::Keyword::MEDIUMTEXT => {}
                     sqlparser::keywords::Keyword::MEMBER => {}
                     sqlparser::keywords::Keyword::MERGE => {}
                     sqlparser::keywords::Keyword::METADATA => {}
@@ -9085,6 +9830,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::ONE => {}
                     sqlparser::keywords::Keyword::ONLY => {}
                     sqlparser::keywords::Keyword::OPEN => {}
+                    sqlparser::keywords::Keyword::OPENJSON => {}
                     sqlparser::keywords::Keyword::OPERATOR => {}
                     sqlparser::keywords::Keyword::OPTIMIZE => {}
                     sqlparser::keywords::Keyword::OPTIMIZER_COSTS => {}
@@ -9158,6 +9904,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::READS => {}
                     sqlparser::keywords::Keyword::READ_ONLY => {}
                     sqlparser::keywords::Keyword::REAL => {}
+                    sqlparser::keywords::Keyword::RECLUSTER => {}
                     sqlparser::keywords::Keyword::RECURSIVE => {}
                     sqlparser::keywords::Keyword::REF => {}
                     sqlparser::keywords::Keyword::REFERENCES => {}
@@ -9192,6 +9939,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::RESTRICTIVE => {}
                     sqlparser::keywords::Keyword::RESULT => {}
                     sqlparser::keywords::Keyword::RESULTSET => {}
+                    sqlparser::keywords::Keyword::RESUME => {}
                     sqlparser::keywords::Keyword::RETAIN => {}
                     sqlparser::keywords::Keyword::RETURN => {}
                     sqlparser::keywords::Keyword::RETURNING => {}
@@ -9200,6 +9948,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::RIGHT => {}
                     sqlparser::keywords::Keyword::RLIKE => {}
                     sqlparser::keywords::Keyword::ROLE => {}
+                    sqlparser::keywords::Keyword::ROLES => {}
                     sqlparser::keywords::Keyword::ROLLBACK => {}
                     sqlparser::keywords::Keyword::ROLLUP => {}
                     sqlparser::keywords::Keyword::ROOT => {}
@@ -9211,6 +9960,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::RUN => {}
                     sqlparser::keywords::Keyword::SAFE => {}
                     sqlparser::keywords::Keyword::SAFE_CAST => {}
+                    sqlparser::keywords::Keyword::SAMPLE => {}
                     sqlparser::keywords::Keyword::SAVEPOINT => {}
                     sqlparser::keywords::Keyword::SCHEMA => {}
                     sqlparser::keywords::Keyword::SCHEMAS => {}
@@ -9218,8 +9968,10 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::SCROLL => {}
                     sqlparser::keywords::Keyword::SEARCH => {}
                     sqlparser::keywords::Keyword::SECOND => {}
+                    sqlparser::keywords::Keyword::SECONDARY => {}
                     sqlparser::keywords::Keyword::SECRET => {}
                     sqlparser::keywords::Keyword::SECURITY => {}
+                    sqlparser::keywords::Keyword::SEED => {}
                     sqlparser::keywords::Keyword::SELECT => {}
                     sqlparser::keywords::Keyword::SEMI => {}
                     sqlparser::keywords::Keyword::SENSITIVE => {}
@@ -9257,6 +10009,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::STABLE => {}
                     sqlparser::keywords::Keyword::STAGE => {}
                     sqlparser::keywords::Keyword::START => {}
+                    sqlparser::keywords::Keyword::STARTS => {}
                     sqlparser::keywords::Keyword::STATEMENT => {}
                     sqlparser::keywords::Keyword::STATIC => {}
                     sqlparser::keywords::Keyword::STATISTICS => {}
@@ -9278,6 +10031,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::SUM => {}
                     sqlparser::keywords::Keyword::SUPER => {}
                     sqlparser::keywords::Keyword::SUPERUSER => {}
+                    sqlparser::keywords::Keyword::SUSPEND => {}
                     sqlparser::keywords::Keyword::SWAP => {}
                     sqlparser::keywords::Keyword::SYMMETRIC => {}
                     sqlparser::keywords::Keyword::SYNC => {}
@@ -9293,6 +10047,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::TEMP => {}
                     sqlparser::keywords::Keyword::TEMPORARY => {}
                     sqlparser::keywords::Keyword::TERMINATED => {}
+                    sqlparser::keywords::Keyword::TERSE => {}
                     sqlparser::keywords::Keyword::TEXT => {}
                     sqlparser::keywords::Keyword::TEXTFILE => {}
                     sqlparser::keywords::Keyword::THEN => {}
@@ -9306,7 +10061,9 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::TIMEZONE_HOUR => {}
                     sqlparser::keywords::Keyword::TIMEZONE_MINUTE => {}
                     sqlparser::keywords::Keyword::TIMEZONE_REGION => {}
+                    sqlparser::keywords::Keyword::TINYBLOB => {}
                     sqlparser::keywords::Keyword::TINYINT => {}
+                    sqlparser::keywords::Keyword::TINYTEXT => {}
                     sqlparser::keywords::Keyword::TO => {}
                     sqlparser::keywords::Keyword::TOP => {}
                     sqlparser::keywords::Keyword::TOTALS => {}
@@ -9340,6 +10097,7 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
                     sqlparser::keywords::Keyword::UNION => {}
                     sqlparser::keywords::Keyword::UNIQUE => {}
                     sqlparser::keywords::Keyword::UNKNOWN => {}
+                    sqlparser::keywords::Keyword::UNLISTEN => {}
                     sqlparser::keywords::Keyword::UNLOAD => {}
                     sqlparser::keywords::Keyword::UNLOCK => {}
                     sqlparser::keywords::Keyword::UNLOGGED => {}
@@ -9403,6 +10161,46 @@ impl crate::Visitable for sqlparser::keywords::Keyword {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::keywords::Keyword {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::tokenizer::Location {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.line.accept(visitor)?;
+                self.column.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::tokenizer::Location {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::tokenizer::Span {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.start.accept(visitor)?;
+                self.end.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::tokenizer::Span {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::tokenizer::Token {
     fn accept<'ast, V: crate::Visitor<'ast>>(
@@ -9556,6 +10354,26 @@ impl crate::Visitable for sqlparser::tokenizer::Token {
 }
 #[automatically_derived]
 impl crate::Semantic for sqlparser::tokenizer::Token {}
+#[automatically_derived]
+impl crate::Visitable for sqlparser::tokenizer::TokenWithSpan {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.token.accept(visitor)?;
+                self.span.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::Semantic for sqlparser::tokenizer::TokenWithSpan {}
 #[automatically_derived]
 impl crate::Visitable for sqlparser::tokenizer::Whitespace {
     fn accept<'ast, V: crate::Visitor<'ast>>(

--- a/packages/sqltk/src/lib.rs
+++ b/packages/sqltk/src/lib.rs
@@ -7,10 +7,10 @@
 //! ## Key features
 //!
 //! 1. Full coverage of all AST node types from `sqlparser` (including all field types and container types (`Vec`,
-//! `Option` & `Box`)) and terminal nodes.
+//!    `Option` & `Box`)) and terminal nodes.
 //!
 //! 2. [`Transform`] trait methods do not receive a mutable node argument which means that non-mutable references AST
-//! nodes can be retained in your own data structures from previous analysis passes.
+//!    nodes can be retained in your own data structures from previous analysis passes.
 //!
 //! ## Installation
 //!
@@ -75,7 +75,11 @@ mod transform;
 mod transformable_impls;
 mod visitable_impls;
 
-use sqlparser::ast::{Expr, ObjectName, Statement};
+#[doc(inline)]
+pub use sqlparser::{self};
+
+use crate::sqlparser::ast::{Expr, ObjectName, Statement};
+
 pub use transform::*;
 
 use core::fmt::Debug;


### PR DESCRIPTION
`sqltk` now depends on a specific git commit from the CipherStash fork of `sqlparser`

`sqlparser` is now re-exported from sqltk.

This is due to the generated (derived) `Visit` and `Transform` implementations being included verbatim in sqltk itself.

In order to prevent compilation issues, consumers of sqltk *must* use the version of `sqlparser` that is re-exported from `sqltk`, until we get around to automating the code generation in a `build.rs`.