### PR TITLE
Re-exports sqltk_parser as sqltk::parser

### DIFF
--- a/packages/sqltk/src/lib.rs
+++ b/packages/sqltk/src/lib.rs
@@ -73,6 +73,13 @@ mod transform;
 mod transformable_impls;
 mod visitable_impls;
 
+// Re-export sqltk-parser under this lib as `sqltk::parser`, so we can avoid
+// needing to expose the machinations of the versioning of our
+// forked-but-with-upstream-updates sqlparser.
+pub mod parser {
+    pub use sqltk_parser::*;
+}
+
 pub use node_key::*;
 use sqltk_parser::ast::{Expr, ObjectName, Statement};
 pub use transform::*;


### PR DESCRIPTION
Re-exports `sqltk-parser` as as `sqltk::parser`, so we can avoid needing to expose the machinations of the versioning when it comes to modifying (temporarily, or otherwise) the upstream sqlparser.