### PR TITLE
Parse Postgres's LOCK TABLE statement

### DIFF
--- a/packages/sqltk-parser/src/ast/mod.rs
+++ b/packages/sqltk-parser/src/ast/mod.rs
@@ -3327,16 +3327,13 @@ pub enum Statement {
         value: Option<Value>,
         is_eq: bool,
     },
-    /// ```sql
-    /// LOCK TABLES <table_name> [READ [LOCAL] | [LOW_PRIORITY] WRITE]
-    /// ```
-    /// Note: this is a MySQL-specific statement. See <https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html>
-    LockTables { tables: Vec<LockTable> },
+    /// See [`LockTables`].
+    LockTables(LockTables),
     /// ```sql
     /// UNLOCK TABLES
     /// ```
     /// Note: this is a MySQL-specific statement. See <https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html>
-    UnlockTables,
+    UnlockTables(bool),
     /// ```sql
     /// UNLOAD(statement) TO <destination> [ WITH options ]
     /// ```
@@ -4877,11 +4874,15 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::LockTables { tables } => {
-                write!(f, "LOCK TABLES {}", display_comma_separated(tables))
+            Statement::LockTables(lock_tables) => {
+                write!(f, "{}", lock_tables)
             }
-            Statement::UnlockTables => {
-                write!(f, "UNLOCK TABLES")
+            Statement::UnlockTables(pluralized) => {
+                if *pluralized {
+                    write!(f, "UNLOCK TABLES")
+                } else {
+                    write!(f, "UNLOCK TABLE")
+                }
             }
             Statement::Unload { query, to, with } => {
                 write!(f, "UNLOAD({query}) TO {to}")?;
@@ -7227,16 +7228,126 @@ impl fmt::Display for SearchModifier {
     }
 }
 
+/// A `LOCK TABLE ..` statement. MySQL and Postgres variants are supported.
+///
+/// The MySQL and Postgres syntax variants are significant enough that they
+/// are explicitly represented as enum variants. In order to support additional
+/// databases in the future, this enum is marked as `#[non_exhaustive]`.
+///
+/// In MySQL, when multiple tables are mentioned in the statement the lock mode
+/// can vary per table.
+///
+/// In contrast, Postgres only allows specifying a single mode which is applied
+/// to all mentioned tables.
+///
+/// MySQL: see <https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html>
+///
+/// ```sql
+/// LOCK [TABLE | TABLES] name [[AS] alias] locktype [,name [[AS] alias] locktype]
+/// ````
+///
+/// Where *locktype* is:
+/// ```sql
+/// READ [LOCAL] | [LOW_PRIORITY] WRITE
+/// ```
+///
+/// Postgres: See <https://www.postgresql.org/docs/current/sql-lock.html>
+///
+/// ```sql
+/// LOCK [ TABLE ] [ ONLY ] name [, ...] [ IN lockmode MODE ] [ NOWAIT ]
+/// ```
+/// Where *lockmode* is one of:
+///
+/// ```sql
+/// ACCESS SHARE | ROW SHARE | ROW EXCLUSIVE | SHARE UPDATE EXCLUSIVE
+/// | SHARE | SHARE ROW EXCLUSIVE | EXCLUSIVE | ACCESS EXCLUSIVE
+/// ``````
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
-pub struct LockTable {
-    pub table: Ident,
-    pub alias: Option<Ident>,
-    pub lock_type: LockTableType,
+#[non_exhaustive]
+pub enum LockTables {
+    /// The MySQL syntax variant
+    MySql {
+        /// Whether the `TABLE` or `TABLES` keyword was used.
+        pluralized_table_keyword: bool,
+        /// The tables to lock and their per-table lock mode.
+        tables: Vec<MySqlTableLock>,
+    },
+
+    /// The Postgres syntax variant.
+    Postgres {
+        /// One or more optionally schema-qualified table names to lock.
+        tables: Vec<ObjectName>,
+        /// The lock type applied to all mentioned tables.
+        lock_mode: Option<LockTableType>,
+        /// Whether the optional `TABLE` keyword was present (to support round-trip parse & render)
+        has_table_keyword: bool,
+        /// Whether the `ONLY` option was specified.
+        only: bool,
+        /// Whether the `NOWAIT` option was specified.
+        no_wait: bool,
+    },
 }
 
-impl fmt::Display for LockTable {
+impl Display for LockTables {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LockTables::MySql {
+                pluralized_table_keyword,
+                tables,
+            } => {
+                write!(
+                    f,
+                    "LOCK {tbl_kwd} ",
+                    tbl_kwd = if *pluralized_table_keyword {
+                        "TABLES"
+                    } else {
+                        "TABLE"
+                    }
+                )?;
+                write!(f, "{}", display_comma_separated(tables))?;
+                Ok(())
+            }
+            LockTables::Postgres {
+                tables,
+                lock_mode,
+                has_table_keyword,
+                only,
+                no_wait,
+            } => {
+                write!(
+                    f,
+                    "LOCK{tbl_kwd}",
+                    tbl_kwd = if *has_table_keyword { " TABLE" } else { "" }
+                )?;
+                if *only {
+                    write!(f, " ONLY")?;
+                }
+                write!(f, " {}", display_comma_separated(tables))?;
+                if let Some(lock_mode) = lock_mode {
+                    write!(f, " IN {} MODE", lock_mode)?;
+                }
+                if *no_wait {
+                    write!(f, " NOWAIT")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// A locked table from a MySQL `LOCK TABLE` statement.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct MySqlTableLock {
+    pub table: ObjectName,
+    pub alias: Option<Ident>,
+    pub lock_type: Option<LockTableType>,
+}
+
+impl fmt::Display for MySqlTableLock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             table: tbl_name,
@@ -7248,17 +7359,34 @@ impl fmt::Display for LockTable {
         if let Some(alias) = alias {
             write!(f, "AS {alias} ")?;
         }
-        write!(f, "{lock_type}")?;
+        if let Some(lock_type) = lock_type {
+            write!(f, "{lock_type}")?;
+        }
         Ok(())
     }
 }
 
+/// Table lock types.
+///
+/// `Read` & `Write` are MySQL-specfic.
+///
+/// AccessShare, RowShare, RowExclusive, ShareUpdateExclusive, Share,
+/// ShareRowExclusive, Exclusive, AccessExclusive are Postgres-specific.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[non_exhaustive]
 pub enum LockTableType {
     Read { local: bool },
     Write { low_priority: bool },
+    AccessShare,
+    RowShare,
+    RowExclusive,
+    ShareUpdateExclusive,
+    Share,
+    ShareRowExclusive,
+    Exclusive,
+    AccessExclusive,
 }
 
 impl fmt::Display for LockTableType {
@@ -7275,6 +7403,30 @@ impl fmt::Display for LockTableType {
                     write!(f, "LOW_PRIORITY ")?;
                 }
                 write!(f, "WRITE")?;
+            }
+            Self::AccessShare => {
+                write!(f, "ACCESS SHARE")?;
+            }
+            Self::RowShare => {
+                write!(f, "ROW SHARE")?;
+            }
+            Self::RowExclusive => {
+                write!(f, "ROW EXCLUSIVE")?;
+            }
+            Self::ShareUpdateExclusive => {
+                write!(f, "SHARE UPDATE EXCLUSIVE")?;
+            }
+            Self::Share => {
+                write!(f, "SHARE")?;
+            }
+            Self::ShareRowExclusive => {
+                write!(f, "SHARE ROW EXCLUSIVE")?;
+            }
+            Self::Exclusive => {
+                write!(f, "EXCLUSIVE")?;
+            }
+            Self::AccessExclusive => {
+                write!(f, "ACCESS EXCLUSIVE")?;
             }
         }
 
@@ -7628,6 +7780,22 @@ impl Display for JsonNullClause {
             JsonNullClause::NullOnNull => write!(f, "NULL ON NULL"),
             JsonNullClause::AbsentOnNull => write!(f, "ABSENT ON NULL"),
         }
+    }
+}
+
+/// rename object definition
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct RenameTable {
+    pub old_name: ObjectName,
+    pub new_name: ObjectName,
+}
+
+impl fmt::Display for RenameTable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} TO {}", self.old_name, self.new_name)?;
+        Ok(())
     }
 }
 

--- a/packages/sqltk-parser/src/ast/spans.rs
+++ b/packages/sqltk-parser/src/ast/spans.rs
@@ -477,7 +477,7 @@ impl Spanned for Statement {
             Statement::CreateType { .. } => Span::empty(),
             Statement::Pragma { .. } => Span::empty(),
             Statement::LockTables { .. } => Span::empty(),
-            Statement::UnlockTables => Span::empty(),
+            Statement::UnlockTables(_) => Span::empty(),
             Statement::Unload { .. } => Span::empty(),
             Statement::OptimizeTable { .. } => Span::empty(),
             Statement::CreatePolicy { .. } => Span::empty(),

--- a/packages/sqltk-parser/src/dialect/mysql.rs
+++ b/packages/sqltk-parser/src/dialect/mysql.rs
@@ -19,7 +19,7 @@
 use alloc::boxed::Box;
 
 use crate::{
-    ast::{BinaryOperator, Expr, LockTable, LockTableType, Statement},
+    ast::{BinaryOperator, Expr, LockTableType, LockTables, MySqlTableLock, Statement},
     dialect::Dialect,
     keywords::Keyword,
     parser::{Parser, ParserError},
@@ -81,10 +81,14 @@ impl Dialect for MySqlDialect {
     }
 
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
-        if parser.parse_keywords(&[Keyword::LOCK, Keyword::TABLES]) {
-            Some(parse_lock_tables(parser))
+        if parser.parse_keywords(&[Keyword::LOCK, Keyword::TABLE]) {
+            Some(parse_lock_tables(parser, false))
+        } else if parser.parse_keywords(&[Keyword::LOCK, Keyword::TABLES]) {
+            Some(parse_lock_tables(parser, true))
+        } else if parser.parse_keywords(&[Keyword::UNLOCK, Keyword::TABLE]) {
+            Some(parse_unlock_tables(parser, false))
         } else if parser.parse_keywords(&[Keyword::UNLOCK, Keyword::TABLES]) {
-            Some(parse_unlock_tables(parser))
+            Some(parse_unlock_tables(parser, true))
         } else {
             None
         }
@@ -106,22 +110,28 @@ impl Dialect for MySqlDialect {
 
 /// `LOCK TABLES`
 /// <https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html>
-fn parse_lock_tables(parser: &mut Parser) -> Result<Statement, ParserError> {
+fn parse_lock_tables(
+    parser: &mut Parser,
+    pluralized_table_keyword: bool,
+) -> Result<Statement, ParserError> {
     let tables = parser.parse_comma_separated(parse_lock_table)?;
-    Ok(Statement::LockTables { tables })
+    Ok(Statement::LockTables(LockTables::MySql {
+        pluralized_table_keyword,
+        tables,
+    }))
 }
 
 // tbl_name [[AS] alias] lock_type
-fn parse_lock_table(parser: &mut Parser) -> Result<LockTable, ParserError> {
-    let table = parser.parse_identifier(false)?;
+fn parse_lock_table(parser: &mut Parser) -> Result<MySqlTableLock, ParserError> {
+    let table = parser.parse_object_name(false)?;
     let alias =
         parser.parse_optional_alias(&[Keyword::READ, Keyword::WRITE, Keyword::LOW_PRIORITY])?;
     let lock_type = parse_lock_tables_type(parser)?;
 
-    Ok(LockTable {
+    Ok(MySqlTableLock {
         table,
         alias,
-        lock_type,
+        lock_type: Some(lock_type),
     })
 }
 
@@ -146,6 +156,9 @@ fn parse_lock_tables_type(parser: &mut Parser) -> Result<LockTableType, ParserEr
 
 /// UNLOCK TABLES
 /// <https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html>
-fn parse_unlock_tables(_parser: &mut Parser) -> Result<Statement, ParserError> {
-    Ok(Statement::UnlockTables)
+fn parse_unlock_tables(
+    _parser: &mut Parser,
+    pluralized_table: bool,
+) -> Result<Statement, ParserError> {
+    Ok(Statement::UnlockTables(pluralized_table))
 }

--- a/packages/sqltk-parser/src/dialect/postgresql.rs
+++ b/packages/sqltk-parser/src/dialect/postgresql.rs
@@ -28,11 +28,14 @@
 // limitations under the License.
 use log::debug;
 
-use crate::ast::{ObjectName, Statement, UserDefinedTypeRepresentation};
+use crate::ast::{LockTableType, LockTables, ObjectName, Statement, UserDefinedTypeRepresentation};
 use crate::dialect::{Dialect, Precedence};
 use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
 use crate::tokenizer::Token;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// A [`Dialect`] for [PostgreSQL](https://www.postgresql.org/)
 #[derive(Debug)]
@@ -139,6 +142,9 @@ impl Dialect for PostgreSqlDialect {
         if parser.parse_keyword(Keyword::CREATE) {
             parser.prev_token(); // unconsume the CREATE in case we don't end up parsing anything
             parse_create(parser)
+        } else if parser.parse_keyword(Keyword::LOCK) {
+            parser.prev_token(); // unconsume the LOCK in case we don't end up parsing anything
+            Some(parse_lock_table(parser))
         } else {
             None
         }
@@ -265,4 +271,52 @@ pub fn parse_create_type_as_enum(
         name,
         representation: UserDefinedTypeRepresentation::Enum { labels },
     })
+}
+
+pub fn parse_lock_table(parser: &mut Parser) -> Result<Statement, ParserError> {
+    parser.expect_keyword(Keyword::LOCK)?;
+    let has_table_keyword = parser.parse_keyword(Keyword::TABLE);
+    let only = parser.parse_keyword(Keyword::ONLY);
+    let tables: Vec<ObjectName> =
+        parser.parse_comma_separated(|parser| parser.parse_object_name(false))?;
+    let lock_mode = parse_lock_mode(parser)?;
+    let no_wait = parser.parse_keyword(Keyword::NOWAIT);
+
+    Ok(Statement::LockTables(LockTables::Postgres {
+        tables,
+        lock_mode,
+        has_table_keyword,
+        only,
+        no_wait,
+    }))
+}
+
+pub fn parse_lock_mode(parser: &mut Parser) -> Result<Option<LockTableType>, ParserError> {
+    if !parser.parse_keyword(Keyword::IN) {
+        return Ok(None);
+    }
+
+    let lock_mode = if parser.parse_keywords(&[Keyword::ACCESS, Keyword::SHARE]) {
+        LockTableType::AccessShare
+    } else if parser.parse_keywords(&[Keyword::ACCESS, Keyword::EXCLUSIVE]) {
+        LockTableType::AccessExclusive
+    } else if parser.parse_keywords(&[Keyword::EXCLUSIVE]) {
+        LockTableType::Exclusive
+    } else if parser.parse_keywords(&[Keyword::ROW, Keyword::EXCLUSIVE]) {
+        LockTableType::RowExclusive
+    } else if parser.parse_keywords(&[Keyword::ROW, Keyword::SHARE]) {
+        LockTableType::RowShare
+    } else if parser.parse_keywords(&[Keyword::SHARE, Keyword::ROW, Keyword::EXCLUSIVE]) {
+        LockTableType::ShareRowExclusive
+    } else if parser.parse_keywords(&[Keyword::SHARE, Keyword::UPDATE, Keyword::EXCLUSIVE]) {
+        LockTableType::ShareUpdateExclusive
+    } else if parser.parse_keywords(&[Keyword::SHARE]) {
+        LockTableType::Share
+    } else {
+        return Err(ParserError::ParserError("Expected: ACCESS EXCLUSIVE | ACCESS SHARE | EXCLUSIVE | ROW EXCLUSIVE | ROW SHARE | SHARE | SHARE ROW EXCLUSIVE | SHARE ROW EXCLUSIVE".into()));
+    };
+
+    parser.expect_keyword(Keyword::MODE)?;
+
+    Ok(Some(lock_mode))
 }

--- a/packages/sqltk-parser/tests/sqlparser_postgres_cipherstash.rs
+++ b/packages/sqltk-parser/tests/sqlparser_postgres_cipherstash.rs
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![warn(clippy::all)]
+//! Test SQL syntax specific to PostgreSQL. The parser based on the
+//! generic dialect is also tested (on the inputs it can handle).
+
+#[macro_use]
+mod test_utils;
+use test_utils::*;
+
+use sqltk_parser::dialect::{GenericDialect, PostgreSqlDialect};
+
+// Helpers
+
+fn pg() -> TestedDialects {
+    TestedDialects::new(vec![Box::new(PostgreSqlDialect {})])
+}
+
+fn pg_and_generic() -> TestedDialects {
+    TestedDialects::new(vec![
+        Box::new(PostgreSqlDialect {}),
+        Box::new(GenericDialect {}),
+    ])
+}
+
+// Tests
+
+#[test]
+fn parse_select_without_projection() {
+    pg_and_generic().verified_stmt("SELECT FROM users");
+}
+
+#[test]
+fn parse_lock_table() {
+    pg().verified_stmt("LOCK customers");
+    pg().verified_stmt("LOCK TABLE customers");
+    pg().verified_stmt("LOCK TABLE ONLY customers");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ACCESS SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ROW SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN SHARE UPDATE EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN SHARE ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ACCESS EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK customers, orders");
+    pg().verified_stmt("LOCK TABLE customers, orders");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ACCESS SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ROW SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN SHARE UPDATE EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN SHARE ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ACCESS EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ACCESS SHARE MODE NOWAIT");
+}

--- a/packages/sqltk-parser/tests/sqlparser_postgres_cipherstash.rs
+++ b/packages/sqltk-parser/tests/sqlparser_postgres_cipherstash.rs
@@ -23,7 +23,7 @@
 mod test_utils;
 use test_utils::*;
 
-use sqltk_parser::dialect::{GenericDialect, PostgreSqlDialect};
+use sqltk_parser::dialect::PostgreSqlDialect;
 
 // Helpers
 
@@ -31,19 +31,15 @@ fn pg() -> TestedDialects {
     TestedDialects::new(vec![Box::new(PostgreSqlDialect {})])
 }
 
-fn pg_and_generic() -> TestedDialects {
-    TestedDialects::new(vec![
-        Box::new(PostgreSqlDialect {}),
-        Box::new(GenericDialect {}),
-    ])
-}
-
 // Tests
 
-#[test]
-fn parse_select_without_projection() {
-    pg_and_generic().verified_stmt("SELECT FROM users");
-}
+// TODO: Uncomment this when resolved. Not *directly* relevant to the LOCK TABLE
+//       work, but still valid SQL we should support.
+//       See sqlparser_postgres.rs:2969 for the definition of pg_and_generic().
+//#[test]
+//fn parse_select_without_projection() {
+//    pg_and_generic().verified_stmt("SELECT FROM users");
+//}
 
 #[test]
 fn parse_lock_table() {

--- a/packages/sqltk/src/generated/transformable_impls.rs
+++ b/packages/sqltk/src/generated/transformable_impls.rs
@@ -6940,30 +6940,6 @@ impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::LockClause {
     }
 }
 #[automatically_derived]
-impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::LockTable {
-    fn apply_transform_with_path<T>(
-        &'ast self,
-        transformer: &mut T,
-        node_path: &mut crate::NodePath<'ast>,
-    ) -> Result<Self, T::Error>
-    where
-        T: crate::Transform<'ast>,
-    {
-        node_path.push(self);
-        let transformed = {
-            let Self { table, alias, lock_type } = self;
-            Self {
-                table: table.apply_transform_with_path(transformer, node_path)?,
-                alias: alias.apply_transform_with_path(transformer, node_path)?,
-                lock_type: lock_type.apply_transform_with_path(transformer, node_path)?,
-            }
-        };
-        let transformed = transformer.transform(node_path, transformed)?;
-        node_path.pop();
-        Ok(transformed)
-    }
-}
-#[automatically_derived]
 impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::LockTableType {
     fn apply_transform_with_path<T>(
         &'ast self,
@@ -6987,6 +6963,110 @@ impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::LockTableType {
                             .apply_transform_with_path(transformer, node_path)?,
                     }
                 }
+                sqltk_parser::ast::LockTableType::AccessShare => {
+                    transformer
+                        .transform(
+                            node_path,
+                            sqltk_parser::ast::LockTableType::AccessShare,
+                        )?
+                }
+                sqltk_parser::ast::LockTableType::RowShare => {
+                    transformer
+                        .transform(
+                            node_path,
+                            sqltk_parser::ast::LockTableType::RowShare,
+                        )?
+                }
+                sqltk_parser::ast::LockTableType::RowExclusive => {
+                    transformer
+                        .transform(
+                            node_path,
+                            sqltk_parser::ast::LockTableType::RowExclusive,
+                        )?
+                }
+                sqltk_parser::ast::LockTableType::ShareUpdateExclusive => {
+                    transformer
+                        .transform(
+                            node_path,
+                            sqltk_parser::ast::LockTableType::ShareUpdateExclusive,
+                        )?
+                }
+                sqltk_parser::ast::LockTableType::Share => {
+                    transformer
+                        .transform(node_path, sqltk_parser::ast::LockTableType::Share)?
+                }
+                sqltk_parser::ast::LockTableType::ShareRowExclusive => {
+                    transformer
+                        .transform(
+                            node_path,
+                            sqltk_parser::ast::LockTableType::ShareRowExclusive,
+                        )?
+                }
+                sqltk_parser::ast::LockTableType::Exclusive => {
+                    transformer
+                        .transform(
+                            node_path,
+                            sqltk_parser::ast::LockTableType::Exclusive,
+                        )?
+                }
+                sqltk_parser::ast::LockTableType::AccessExclusive => {
+                    transformer
+                        .transform(
+                            node_path,
+                            sqltk_parser::ast::LockTableType::AccessExclusive,
+                        )?
+                }
+                _ => unreachable!(),
+            }
+        };
+        let transformed = transformer.transform(node_path, transformed)?;
+        node_path.pop();
+        Ok(transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::LockTables {
+    fn apply_transform_with_path<T>(
+        &'ast self,
+        transformer: &mut T,
+        node_path: &mut crate::NodePath<'ast>,
+    ) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        node_path.push(self);
+        let transformed = {
+            match self {
+                sqltk_parser::ast::LockTables::MySql {
+                    pluralized_table_keyword,
+                    tables,
+                } => {
+                    sqltk_parser::ast::LockTables::MySql {
+                        pluralized_table_keyword: pluralized_table_keyword
+                            .apply_transform_with_path(transformer, node_path)?,
+                        tables: tables.apply_transform_with_path(transformer, node_path)?,
+                    }
+                }
+                sqltk_parser::ast::LockTables::Postgres {
+                    tables,
+                    lock_mode,
+                    has_table_keyword,
+                    only,
+                    no_wait,
+                } => {
+                    sqltk_parser::ast::LockTables::Postgres {
+                        tables: tables
+                            .apply_transform_with_path(transformer, node_path)?,
+                        lock_mode: lock_mode
+                            .apply_transform_with_path(transformer, node_path)?,
+                        has_table_keyword: has_table_keyword
+                            .apply_transform_with_path(transformer, node_path)?,
+                        only: only.apply_transform_with_path(transformer, node_path)?,
+                        no_wait: no_wait
+                            .apply_transform_with_path(transformer, node_path)?,
+                    }
+                }
+                _ => unreachable!(),
             }
         };
         let transformed = transformer.transform(node_path, transformed)?;
@@ -7537,6 +7617,30 @@ impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::MySQLColumnPosition
                         field0.apply_transform_with_path(transformer, node_path)?,
                     )
                 }
+            }
+        };
+        let transformed = transformer.transform(node_path, transformed)?;
+        node_path.pop();
+        Ok(transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::MySqlTableLock {
+    fn apply_transform_with_path<T>(
+        &'ast self,
+        transformer: &mut T,
+        node_path: &mut crate::NodePath<'ast>,
+    ) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        node_path.push(self);
+        let transformed = {
+            let Self { table, alias, lock_type } = self;
+            Self {
+                table: table.apply_transform_with_path(transformer, node_path)?,
+                alias: alias.apply_transform_with_path(transformer, node_path)?,
+                lock_type: lock_type.apply_transform_with_path(transformer, node_path)?,
             }
         };
         let transformed = transformer.transform(node_path, transformed)?;
@@ -8468,6 +8572,29 @@ impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::RenameSelectItem {
                         field0.apply_transform_with_path(transformer, node_path)?,
                     )
                 }
+            }
+        };
+        let transformed = transformer.transform(node_path, transformed)?;
+        node_path.pop();
+        Ok(transformed)
+    }
+}
+#[automatically_derived]
+impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::RenameTable {
+    fn apply_transform_with_path<T>(
+        &'ast self,
+        transformer: &mut T,
+        node_path: &mut crate::NodePath<'ast>,
+    ) -> Result<Self, T::Error>
+    where
+        T: crate::Transform<'ast>,
+    {
+        node_path.push(self);
+        let transformed = {
+            let Self { old_name, new_name } = self;
+            Self {
+                old_name: old_name.apply_transform_with_path(transformer, node_path)?,
+                new_name: new_name.apply_transform_with_path(transformer, node_path)?,
             }
         };
         let transformed = transformer.transform(node_path, transformed)?;
@@ -10877,17 +11004,15 @@ impl<'ast> crate::Transformable<'ast> for sqltk_parser::ast::Statement {
                         is_eq: is_eq.apply_transform_with_path(transformer, node_path)?,
                     }
                 }
-                sqltk_parser::ast::Statement::LockTables { tables } => {
-                    sqltk_parser::ast::Statement::LockTables {
-                        tables: tables.apply_transform_with_path(transformer, node_path)?,
-                    }
+                sqltk_parser::ast::Statement::LockTables(field0) => {
+                    sqltk_parser::ast::Statement::LockTables(
+                        field0.apply_transform_with_path(transformer, node_path)?,
+                    )
                 }
-                sqltk_parser::ast::Statement::UnlockTables => {
-                    transformer
-                        .transform(
-                            node_path,
-                            sqltk_parser::ast::Statement::UnlockTables,
-                        )?
+                sqltk_parser::ast::Statement::UnlockTables(field0) => {
+                    sqltk_parser::ast::Statement::UnlockTables(
+                        field0.apply_transform_with_path(transformer, node_path)?,
+                    )
                 }
                 sqltk_parser::ast::Statement::Unload { query, to, with } => {
                     sqltk_parser::ast::Statement::Unload {

--- a/packages/sqltk/src/generated/visitable_impls.rs
+++ b/packages/sqltk/src/generated/visitable_impls.rs
@@ -5178,31 +5178,6 @@ impl crate::AsNodeKey for sqltk_parser::ast::LockClause {
     }
 }
 #[automatically_derived]
-impl crate::Visitable for sqltk_parser::ast::LockTable {
-    fn accept<'ast, V: crate::Visitor<'ast>>(
-        &'ast self,
-        visitor: &mut V,
-    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
-        visit(
-            self,
-            visitor,
-            #[allow(unused_variables)]
-            |visitor| {
-                self.table.accept(visitor)?;
-                self.alias.accept(visitor)?;
-                self.lock_type.accept(visitor)?;
-                std::ops::ControlFlow::Continue(())
-            },
-        )
-    }
-}
-#[automatically_derived]
-impl crate::AsNodeKey for sqltk_parser::ast::LockTable {
-    fn as_node_key(&self) -> crate::NodeKey<'_> {
-        crate::NodeKey::new(self)
-    }
-}
-#[automatically_derived]
 impl crate::Visitable for sqltk_parser::ast::LockTableType {
     fn accept<'ast, V: crate::Visitor<'ast>>(
         &'ast self,
@@ -5220,6 +5195,15 @@ impl crate::Visitable for sqltk_parser::ast::LockTableType {
                     sqltk_parser::ast::LockTableType::Write { low_priority } => {
                         low_priority.accept(visitor)?;
                     }
+                    sqltk_parser::ast::LockTableType::AccessShare => {}
+                    sqltk_parser::ast::LockTableType::RowShare => {}
+                    sqltk_parser::ast::LockTableType::RowExclusive => {}
+                    sqltk_parser::ast::LockTableType::ShareUpdateExclusive => {}
+                    sqltk_parser::ast::LockTableType::Share => {}
+                    sqltk_parser::ast::LockTableType::ShareRowExclusive => {}
+                    sqltk_parser::ast::LockTableType::Exclusive => {}
+                    sqltk_parser::ast::LockTableType::AccessExclusive => {}
+                    _ => unreachable!(),
                 }
                 std::ops::ControlFlow::Continue(())
             },
@@ -5228,6 +5212,51 @@ impl crate::Visitable for sqltk_parser::ast::LockTableType {
 }
 #[automatically_derived]
 impl crate::AsNodeKey for sqltk_parser::ast::LockTableType {
+    fn as_node_key(&self) -> crate::NodeKey<'_> {
+        crate::NodeKey::new(self)
+    }
+}
+#[automatically_derived]
+impl crate::Visitable for sqltk_parser::ast::LockTables {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                match self {
+                    sqltk_parser::ast::LockTables::MySql {
+                        pluralized_table_keyword,
+                        tables,
+                    } => {
+                        pluralized_table_keyword.accept(visitor)?;
+                        tables.accept(visitor)?;
+                    }
+                    sqltk_parser::ast::LockTables::Postgres {
+                        tables,
+                        lock_mode,
+                        has_table_keyword,
+                        only,
+                        no_wait,
+                    } => {
+                        tables.accept(visitor)?;
+                        lock_mode.accept(visitor)?;
+                        has_table_keyword.accept(visitor)?;
+                        only.accept(visitor)?;
+                        no_wait.accept(visitor)?;
+                    }
+                    _ => unreachable!(),
+                }
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::AsNodeKey for sqltk_parser::ast::LockTables {
     fn as_node_key(&self) -> crate::NodeKey<'_> {
         crate::NodeKey::new(self)
     }
@@ -5724,6 +5753,31 @@ impl crate::Visitable for sqltk_parser::ast::MySQLColumnPosition {
 }
 #[automatically_derived]
 impl crate::AsNodeKey for sqltk_parser::ast::MySQLColumnPosition {
+    fn as_node_key(&self) -> crate::NodeKey<'_> {
+        crate::NodeKey::new(self)
+    }
+}
+#[automatically_derived]
+impl crate::Visitable for sqltk_parser::ast::MySqlTableLock {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.table.accept(visitor)?;
+                self.alias.accept(visitor)?;
+                self.lock_type.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::AsNodeKey for sqltk_parser::ast::MySqlTableLock {
     fn as_node_key(&self) -> crate::NodeKey<'_> {
         crate::NodeKey::new(self)
     }
@@ -6527,6 +6581,30 @@ impl crate::Visitable for sqltk_parser::ast::RenameSelectItem {
 }
 #[automatically_derived]
 impl crate::AsNodeKey for sqltk_parser::ast::RenameSelectItem {
+    fn as_node_key(&self) -> crate::NodeKey<'_> {
+        crate::NodeKey::new(self)
+    }
+}
+#[automatically_derived]
+impl crate::Visitable for sqltk_parser::ast::RenameTable {
+    fn accept<'ast, V: crate::Visitor<'ast>>(
+        &'ast self,
+        visitor: &mut V,
+    ) -> std::ops::ControlFlow<crate::Break<V::Error>> {
+        visit(
+            self,
+            visitor,
+            #[allow(unused_variables)]
+            |visitor| {
+                self.old_name.accept(visitor)?;
+                self.new_name.accept(visitor)?;
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+    }
+}
+#[automatically_derived]
+impl crate::AsNodeKey for sqltk_parser::ast::RenameTable {
     fn as_node_key(&self) -> crate::NodeKey<'_> {
         crate::NodeKey::new(self)
     }
@@ -8296,10 +8374,12 @@ impl crate::Visitable for sqltk_parser::ast::Statement {
                         value.accept(visitor)?;
                         is_eq.accept(visitor)?;
                     }
-                    sqltk_parser::ast::Statement::LockTables { tables } => {
-                        tables.accept(visitor)?;
+                    sqltk_parser::ast::Statement::LockTables(field0) => {
+                        field0.accept(visitor)?;
                     }
-                    sqltk_parser::ast::Statement::UnlockTables => {}
+                    sqltk_parser::ast::Statement::UnlockTables(field0) => {
+                        field0.accept(visitor)?;
+                    }
                     sqltk_parser::ast::Statement::Unload { query, to, with } => {
                         query.accept(visitor)?;
                         to.accept(visitor)?;


### PR DESCRIPTION
Originally written by @freshtonic, PR'd to sqlparser upstream here: https://github.com/apache/datafusion-sqlparser-rs
/pull/1614

Original commit message below:

> See: https://www.postgresql.org/docs/current/sql-lock.html
> 
> PG's full syntax for this statement is supported:
> 
> ```
> LOCK [ TABLE ] [ ONLY ] name [ * ] [, ...] [ IN lockmode MODE ] [ NOWAIT ]
> 
> where lockmode is one of:
> 
>     ACCESS SHARE | ROW SHARE | ROW EXCLUSIVE | SHARE UPDATE EXCLUSIVE
>     | SHARE | SHARE ROW EXCLUSIVE | EXCLUSIVE | ACCESS EXCLUSIVE
> ```
> 
> MySQL and Postgres have support very different syntax for `LOCK TABLE` and are implemented with a breaking change on the `Statement::LockTables { .. }` variant, turning the variant into one which accepts a `LockTables` enum with variants for MySQL and Postgres.