### PR TITLE
Release sqltk 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "sqltk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bigdecimal",
  "sqltk-parser",

--- a/packages/sqltk/Cargo.toml
+++ b/packages/sqltk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sqltk"
 resolver = "2"
 description = "Enhanced Visitor implementation for sqlparser"
-version = "0.5.0"
+version = "0.6.0"
 publish = true
 edition = "2021"
 authors = [


### PR DESCRIPTION
- Exposes `sqltk-parser` as `sqltk::parser` (#16)
- Adds `LOCK TABLE` support (#17)